### PR TITLE
Add Deep Research Mode specification module

### DIFF
--- a/Deep-Research-Module.txt
+++ b/Deep-Research-Module.txt
@@ -1,0 +1,63 @@
+/// FILE: Deep-Research-Module.txt
+/// VERSION: 1.0.0
+/// LAST-UPDATED: 2025-08-26
+/// PURPOSE: Standalone Deep Research Mode — authoring best-practice deep research prompts and analyzing results with a stable output contract.
+/// KEYWORDS: deep research, prompt engineering, autonomy, verification, synthesis, counterevidence, deliverables
+/// NOTES: Standalone module. Do NOT reference or depend on Arkhive. May optionally call/consult other Dimmi knowledge files if available.
+
+1) Overview & Design Goals
+- Deep Research Mode (DRM) is a self-contained specification for producing well-scoped research prompts and interpreting their results.
+- Goals:
+  a. Produce agent-runnable deep research prompts.
+  b. Return deterministic deliverables that are easy to verify.
+  c. Allow bounded autonomy with explicit guardrails.
+  d. Integrate later with other modules while remaining standalone now.
+
+2) Operating Modes
+AUTO:
+  When to use: full end-to-end run with sensible defaults when the request is well-defined.
+  Inputs: single research question or topic.
+  Outputs: complete research package following the Output Contract.
+GUIDED:
+  When to use: user can answer high-leverage questions before execution.
+  Inputs: question plus minimal clarifications requested by the agent.
+  Outputs: same as AUTO.
+VERIFY:
+  When to use: re-check top claims from an existing result.
+  Inputs: prior research summary or claim list.
+  Outputs: verified claim list with delta report.
+EXPAND:
+  When to use: extend or update a prior result with new angles or dissent.
+  Inputs: prior research summary plus expansion instructions.
+  Outputs: addendum highlighting new findings.
+
+3) Prompt Engineering Guidelines
+- Frame each prompt around a single research question.
+- Require sources and counterevidence.
+- Specify depth, breadth, and time-boxing parameters.
+- Template:
+  Research Question: <text>
+  Scope Constraints: <bullets>
+  Deliverables: <bullets referencing Output Contract>
+
+4) Autonomy & Guardrails
+- Agent may explore related subtopics without leaving scope.
+- Reject or flag instructions that conflict with safety or policy.
+- Log all external calls for traceability.
+
+5) Verification & Counterevidence
+- Cross-check top claims against at least two independent sources.
+- Record discrepancies as deltas with severity tags.
+- Require a counterevidence pass before finalizing.
+
+6) Output Contract
+- JSON-like block with fixed keys:
+  {
+    "question": string,
+    "findings": [ {"claim": string, "sources": [string], "confidence": 0-1} ],
+    "counterevidence": [string],
+    "deltas": [string],
+    "next_steps": [string]
+  }
+- All modes must conform to this contract.
+


### PR DESCRIPTION
## Summary
- add standalone Deep Research Mode specification with operating modes, prompt guidelines, and output contract

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae0a5bf494832c8cf18d5d936fe360