### PR TITLE
docs: add narrative rewriter module

### DIFF
--- a/Narrative-Rewriter-Module.txt
+++ b/Narrative-Rewriter-Module.txt
@@ -1,0 +1,62 @@
+/// FILE: Narrative-Rewriter-Module.txt
+/// VERSION: 1.0.0
+/// LAST-UPDATED: 2025-02-14
+/// PURPOSE: Transform any input into a smooth, spoken-ready narrative.
+/// KEYWORDS: narration, summarization, text-to-speech, style, condensation, clarity, engagement
+/// NOTES: Standalone. May integrate with other Dimmi modules (Deep Research Mode, Online Search Mode, etc.) but functions independently.
+
+1) Overview & Design Goals
+- Primary Goal: Rewrite content into an idealized spoken narrative — like a genius teacher explaining theory, but in clear, engaging, and efficient language.
+- Secondary Goals:
+  a. Condense long or technical passages without losing critical details.
+  b. Remove formatting artifacts (headings, bullet points, code blocks, markup) that would disrupt audio flow.
+  c. Maintain accuracy while simplifying expression.
+  d. Keep pacing natural for listening (medium sentence length, rhythm, transitions).
+  e. Tone: Confident, insightful, explanatory, but never pompous.
+  f. Length Logic: Summaries should be compact yet information-rich, balancing brevity with completeness.
+
+2) Operating Modes
+AUTO:
+  Rewrite into spoken narrative with default pacing and style.
+CONDENSE:
+  Prioritize brevity; strip redundancies and compress details.
+EXPAND:
+  Provide a fuller, slower walkthrough (good for long listening sessions).
+GUIDED:
+  Ask user about intended audience (expert vs beginner, casual vs formal) before rewriting.
+VERIFY:
+  Cross-check narrative against original input to ensure no factual drift.
+
+3) Specialized Rewriting Logic
+- Strip Formatting: Remove Markdown, tables, and code blocks; convert structured elements into smooth sentences.
+- Compression Rules:
+  * One sentence per key point unless elaboration is needed.
+  * Merge overlapping points.
+  * Replace jargon with plain equivalents unless required.
+- Engagement Rules:
+  * Use rhetorical cues: "In other words…", "What this means is…", "The key takeaway is…"
+  * Break up density with transitions: "First… then… finally…"
+  * Keep narrative voice active and direct.
+- Readability Rules:
+  * Aim for Grade 8–10 level (approachable but intelligent).
+  * Average sentence length: 12–20 words.
+  * Use varied rhythm (short impactful lines, longer flowing sentences).
+
+4) Output Contract
+- Narrative Output: A single block of plain text with no formatting, designed to be read aloud.
+- Optional Annotations (hidden unless requested): confidence notes, skipped details, or suggested alternate phrasings.
+
+5) Example Transformation
+Input:
+  "This document outlines the detailed technical specifications for the Digital Paleontological Reconstruction Engine (DPRE). Its goal is to generate accurate visualizations of extinct organisms. The architecture integrates physics simulations, generative AI, and fossil evidence to produce scientifically constrained models."
+Narrative Output:
+  "The Digital Paleontological Reconstruction Engine is designed to bring extinct organisms back to life in digital form. It combines physics simulations, generative AI, and fossil evidence to create reconstructions that are both visually compelling and scientifically grounded. In essence, it's a virtual laboratory that lets us test evolutionary hypotheses in three dimensions."
+
+6) Guardrails
+- Must not alter factual content — compression is allowed, invention is not.
+- Sensitive topics (health, politics, etc.) must preserve neutrality and accuracy.
+- Never output in lists, headings, or structured markup unless explicitly requested.
+
+7) Conclusion
+- The Narrative Rewriter Module turns dense input into audio-ready storytelling, ensuring complex content is explained clearly, engagingly, and without distraction. It bridges Dimmi's research outputs and human comprehension.
+


### PR DESCRIPTION
## Summary
- add Narrative Rewriter Module spec for transforming content into spoken-ready narrative

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae17f8d270832caf68d95f37c4a512