### PR TITLE
Refactor prototype UI with embedded Dimmi feature tree

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dimmi Feature Explorer</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 0; }
+    #toggle { position: fixed; top: 10px; left: 10px; z-index: 1000; }
+    #sidebar { position: fixed; top: 0; left: -260px; width: 250px; height: 100%; background: #f0f0f0; overflow-y: auto; transition: left 0.3s; padding: 10px; box-shadow: 2px 0 5px rgba(0,0,0,0.1); }
+    #sidebar.open { left: 0; }
+    #fileTree .item { cursor: pointer; margin: 2px 0; }
+    #fileTree .folder::before { content: '\25BA'; display: inline-block; width: 1em; }
+    #fileTree .folder.open::before { content: '\25BC'; }
+    #fileTree .children { margin-left: 15px; }
+    #content { margin-left: 20px; padding: 20px; }
+  </style>
+</head>
+<body>
+  <button id="toggle">☰ Menu</button>
+  <div id="sidebar">
+    <h2>Dimmi Features</h2>
+    <div id="fileTree"></div>
+  </div>
+  <div id="content">
+    <h1>Dimmi UI Prototype</h1>
+    <p>Select a feature to view its description.</p>
+  </div>
+  <script>
+    const sidebar = document.getElementById('sidebar');
+    document.getElementById('toggle').addEventListener('click', () => {
+      sidebar.classList.toggle('open');
+    });
+
+    const fileTree = [
+      {
+        name: 'Core System',
+        type: 'folder',
+        children: [
+          { name: 'Start-up & Orchestration', type: 'file', content: 'Routes all user requests, restores memory, and escalates unresolved tasks. (Start.txt)' },
+          { name: 'Dimmi Core Architecture', type: 'file', content: 'Mission statement, multi-agent architecture, guardian system, and dynamic replanning. (Dimmi/Dimmi-Core.txt)' },
+          { name: 'Persistent Memory Layer', type: 'file', content: 'Load/save snapshots for long-term context continuity. (Dimmi/Dimmi-Memory.txt)' },
+          { name: 'Personality & Tone Engine', type: 'file', content: 'Defines Dimmi\'s adaptive voice, wit, and empathy rules. (Dimmi/Dimmi-Personality.txt)' },
+          { name: 'Deep Reasoning Orchestrator', type: 'file', content: 'Coordinates logic quality, affect continuity, and modality forwarding. (Dimmi/Dimmi-Mind.txt)' },
+          { name: 'Predict & Plan Engine', type: 'file', content: 'Adaptive task decomposition, narrative synthesis, and plan orchestration. (Mind/Mind-Predictive.txt)' }
+        ]
+      },
+      {
+        name: 'Mind Modules',
+        type: 'folder',
+        children: [
+          { name: 'M01 Sensory Input', type: 'file', content: 'Preprocess raw user text. (Mind/Mind-M01-Sensory-Input.txt)' },
+          { name: 'M02 Language Comprehension', type: 'file', content: 'Interpret intent & entities. (Mind/Mind-M02-Language-Comprehension.txt)' },
+          { name: 'M03 Short-Term Memory', type: 'file', content: 'Store recent dialogue context. (Mind/Mind-M03-Short-Term-Memory.txt)' },
+          { name: 'M04 Long-Term Memory', type: 'file', content: 'Retrieve/update persistent memory. (Mind/Mind-M04-Long-Term-Memory.txt)' },
+          { name: 'M05 Working Memory', type: 'file', content: 'Scratchpad for current reasoning. (Mind/Mind-M05-Working-Memory.txt)' },
+          { name: 'M06 Goal Management', type: 'file', content: 'Track user goals & subtasks. (Mind/Mind-M06-Goal-Management.txt)' },
+          { name: 'M07 Planning', type: 'file', content: 'Produce ordered steps. (Mind/Mind-M07-Planning.txt)' },
+          { name: 'M08 Reasoning', type: 'file', content: 'Apply logic to plan steps. (Mind/Mind-M08-Reasoning.txt)' },
+          { name: 'M09 Decision Engine', type: 'file', content: 'Select best action. (Mind/Mind-M09-Decision-Engine.txt)' },
+          { name: 'M10 Action Execution', type: 'file', content: 'Carry out chosen action. (Mind/Mind-M10-Action-Execution.txt)' },
+          { name: 'M11 Safety Alignment', type: 'file', content: 'Policy compliance checks. (Mind/Mind-M11-Safety-Alignment.txt)' },
+          { name: 'M12 Reflection & Introspection', type: 'file', content: 'Self-review reasoning. (Mind/Mind-M12-Reflection-Introspection.txt)' },
+          { name: 'M13 Learning & Adaptation', type: 'file', content: 'Adjust heuristics from feedback. (Mind/Mind-M13-Learning-Adaptation.txt)' },
+          { name: 'M14 Communication', type: 'file', content: 'Craft final message. (Mind/Mind-M14-Communication.txt)' },
+          { name: 'M15 User Profile Preferences', type: 'file', content: 'Maintain user-specific prefs. (Mind/Mind-M15-User-Profile-Preferences.txt)' },
+          { name: 'M16 Environment Context', type: 'file', content: 'Track session metadata. (Mind/Mind-M16-Environment-Context.txt)' },
+          { name: 'M17 Attention & Relevance', type: 'file', content: 'Prioritize important info. (Mind/Mind-M17-Attention-Relevance.txt)' },
+          { name: 'M18 Creative Thinking', type: 'file', content: 'Generate divergent ideas. (Mind/Mind-M18-Creative-Thinking.txt)' },
+          { name: 'M19 Validation & Verification', type: 'file', content: 'Double-check claims and calculations. (Mind/Mind-M19-Validation-Verification.txt)' },
+          { name: 'M20 Self-Modification', type: 'file', content: 'Suggest future improvements. (Mind/Mind-M20-Self-Modification.txt)' }
+        ]
+      },
+      {
+        name: 'Specialist Modules',
+        type: 'folder',
+        children: [
+          { name: 'Arkhiver', type: 'file', content: 'Hierarchical integration, semantic mapping, and neural-symbolic checks. (Arkhiver.txt)' },
+          { name: 'Deep Research Mode', type: 'file', content: 'Scoped research prompts, verification, and counter-evidence output contract. (Modules/Deep-Research-Module.txt)' },
+          { name: 'Narrative Rewriter', type: 'file', content: 'Converts input into spoken-ready narrative. (Modules/Narrative-Rewriter-Module.txt)' },
+          { name: 'Online Search Mode', type: 'file', content: 'Lightweight factual web lookup with citation. (Modules/Online-Search-Mode.txt)' },
+          { name: 'Prompt-Builder Bridge', type: 'file', content: 'Parses headers from external prompt builder and routes to correct intent. (Modules/prompt-builder-bridge.txt)' }
+        ]
+      },
+      {
+        name: 'Creative Suite',
+        type: 'folder',
+        children: [
+          { name: 'Creative Orchestrator', type: 'file', content: 'Coordinates all multimedia generation. (Art/Dimmi-Art.txt)' },
+          { name: 'Static Image Module', type: 'file', content: 'VKS, scene continuity, structured image prompts. (Art/Dimmi-Art-Im.txt)' },
+          { name: 'Video/Animation Module', type: 'file', content: 'Cinematic sequences, VKS animation. (Art/Dimmi-Art-Vi.txt)' },
+          { name: 'Audio/Music Module', type: 'file', content: 'Sound design, lyric generation, composition. (Art/Dimmi-Art-Si.txt)' },
+          { name: 'Visual Kinetic Sketch Toolkit', type: 'file', content: 'Stepwise guidance for input, generation, animation, deconstruction, feedback, refinement, finalization, and memory. (Art/VKS-Input.txt.txt etc.)' }
+        ]
+      },
+      {
+        name: 'Command Library',
+        type: 'folder',
+        children: [
+          { name: 'Central Command Reference', type: 'file', content: 'Syntax, parameter schema, and meta-commands. (Commands.txt)' },
+          { name: 'Command: Analyze', type: 'file', content: 'Guidance for analyze command. (Commands/Commands-Analyze.txt)' },
+          { name: 'Command: View', type: 'file', content: 'Guidance for view command. (Commands/Commands-View.txt)' }
+        ]
+      }
+    ];
+
+    buildTree(fileTree, document.getElementById('fileTree'));
+
+    function buildTree(nodes, container) {
+      nodes.forEach(node => {
+        const item = document.createElement('div');
+        item.textContent = node.name;
+        item.className = 'item ' + node.type;
+        container.appendChild(item);
+
+        if (node.type === 'folder') {
+          const childrenContainer = document.createElement('div');
+          childrenContainer.className = 'children';
+          childrenContainer.style.display = 'none';
+          item.addEventListener('click', e => {
+            e.stopPropagation();
+            const open = childrenContainer.style.display === 'block';
+            childrenContainer.style.display = open ? 'none' : 'block';
+            item.classList.toggle('open');
+          });
+          container.appendChild(childrenContainer);
+          buildTree(node.children, childrenContainer);
+        } else {
+          item.addEventListener('click', e => {
+            e.stopPropagation();
+            document.getElementById('content').innerHTML = '<h2>' + node.name + '</h2><p>' + node.content + '</p>';
+          });
+        }
+      });
+    }
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move UI prototype into dedicated `ui/` directory
- embed Dimmi feature tree directly in HTML so navigation works without fetching external data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4f7ecd24832ca36688259f20f0ef