### PR TITLE
refactor: embed file tree script

### DIFF
--- a/UI/fileTree.js
+++ b/UI/fileTree.js
@@ -1,4 +1,4 @@
-[
+const fileTree = [
   {
     "name": "Art",
     "type": "folder",
@@ -85,4 +85,4 @@
       }
     ]
   }
-]
+];

--- a/UI/index.html
+++ b/UI/index.html
@@ -14,6 +14,7 @@
     <h1>Welcome to Dimmi Explorer</h1>
     <p>Select a file from the menu to view its contents or a folder to expand.</p>
   </main>
+  <script src="fileTree.js"></script>
   <script src="ui.js"></script>
 </body>
 </html>

--- a/UI/ui.js
+++ b/UI/ui.js
@@ -3,12 +3,11 @@ document.getElementById('dimmiBtn').addEventListener('click', () => {
   sidebar.classList.toggle('open');
 });
 
-fetch('fileTree.json')
-  .then(r => r.json())
-  .then(data => buildTree(data, document.getElementById('fileTree')))
-  .catch(() => {
-    document.getElementById('content').innerHTML = '<p>Unable to load file tree.</p>';
-  });
+if (typeof fileTree !== 'undefined') {
+  buildTree(fileTree, document.getElementById('fileTree'));
+} else {
+  document.getElementById('content').innerHTML = '<p>Unable to load file tree.</p>';
+}
 
 function buildTree(nodes, container) {
   nodes.forEach(node => {

--- a/generate-file-tree.js
+++ b/generate-file-tree.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const ROOT_DIR = path.join(__dirname, 'Art');
 const OUTPUT_DIR = path.join(__dirname, 'UI');
-const OUTPUT_FILE = path.join(OUTPUT_DIR, 'fileTree.json');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'fileTree.js');
 
 function buildTree(dir) {
   return fs.readdirSync(dir, { withFileTypes: true })
@@ -34,5 +34,8 @@ const tree = [{
 }];
 
 fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-fs.writeFileSync(OUTPUT_FILE, JSON.stringify(tree, null, 2));
-console.log('UI/fileTree.json generated');
+fs.writeFileSync(
+  OUTPUT_FILE,
+  'const fileTree = ' + JSON.stringify(tree, null, 2) + ';\n'
+);
+console.log('UI/fileTree.js generated');


### PR DESCRIPTION
## Summary
- embed prebuilt file tree as JavaScript to avoid fetch errors
- adjust UI scripts to use the embedded file tree
- regenerate fileTree.js with updated generator

## Testing
- `node generate-file-tree.js`
- `node --check generate-file-tree.js UI/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae760bae6c832cbac10f8eed2ea8f9