### PR TITLE
feat: add text file summaries and enhance sidebar UI

### DIFF
--- a/UI/style.css
+++ b/UI/style.css
@@ -1,4 +1,4 @@
-body { font-family: Arial, sans-serif; margin: 0; }
+body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; }
 #dimmiBtn {
   position: fixed;
   top: 10px;
@@ -10,29 +10,52 @@ body { font-family: Arial, sans-serif; margin: 0; }
   padding: 10px 14px;
   border-radius: 4px;
   cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  transition: background 0.3s;
 }
+#dimmiBtn:hover { background: #555; }
 #sidebar {
   position: fixed;
   top: 0;
-  left: -260px;
+  left: 0;
   width: 250px;
   height: 100%;
   background: #f0f0f0;
   overflow-y: auto;
-  transition: left 0.3s;
+  transform: translateX(-260px);
+  transition: transform 0.3s ease;
   padding: 10px;
   box-shadow: 2px 0 5px rgba(0,0,0,0.1);
 }
-#sidebar.open { left: 0; }
-#fileTree .item { cursor: pointer; margin: 2px 0; }
-#fileTree .folder::before { content: '\25BA'; display: inline-block; width: 1em; }
+#sidebar.open { transform: translateX(0); }
+#fileTree .item {
+  cursor: pointer;
+  margin: 2px 0;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  transition: background 0.2s;
+}
+#fileTree .item:hover { background: #e0e0e0; }
+#fileTree .folder::before { content: '\25B6'; display: inline-block; width: 1em; margin-right: 4px; }
 #fileTree .folder.open::before { content: '\25BC'; }
+#fileTree .file::before { content: '\1F4C4'; display: inline-block; width: 1em; margin-right: 4px; }
 #fileTree .children {
   margin-left: 15px;
   max-height: 0;
   overflow: hidden;
-  transition: max-height 0.3s ease;
+  opacity: 0;
+  transition: max-height 0.3s ease, opacity 0.3s ease;
 }
-#fileTree .children.open { max-height: 1000px; }
-#content { margin-left: 20px; padding: 20px; }
+#fileTree .children.open {
+  max-height: 1000px;
+  opacity: 1;
+}
+#content {
+  margin-left: 20px;
+  padding: 20px;
+  transition: margin-left 0.3s ease;
+}
+#sidebar.open ~ #content { margin-left: 270px; }
+.summary { font-style: italic; color: #555; }
 pre { white-space: pre-wrap; }

--- a/UI/ui.js
+++ b/UI/ui.js
@@ -41,8 +41,11 @@ function loadFile(path) {
     .then(res => res.text())
     .then(text => {
       const safe = text.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
+      const summary = text.split(/\n+/).slice(0,3).join(' ').slice(0,200);
+      const safeSummary = summary.replace(/[&<>]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));
       document.getElementById('content').innerHTML =
         '<h2>' + path + '</h2>' +
+        '<p class="summary">' + safeSummary + '</p>' +
         '<p><a href="' + fullPath + '" target="_blank">Open raw file</a></p>' +
         '<pre>' + safe + '</pre>';
     })


### PR DESCRIPTION
## Summary
- show quick summary snippet for opened text files
- modernize sidebar and file tree with icons and smoother transitions

## Testing
- `node UI/generate-file-tree.js`

------
https://chatgpt.com/codex/tasks/task_e_68ae7a6c4ff8832c94b43b9be8e6c9ce