### PR TITLE
feat: show editable file contents

### DIFF
--- a/UI/fileTree.js
+++ b/UI/fileTree.js
@@ -80,6 +80,17 @@ const fileTree = [
         "path": "Art/Dimmi-Art.txt"
       },
       {
+        "name": "Images",
+        "type": "folder",
+        "children": [
+          {
+            "name": "Dimmi-Art-Im.txt",
+            "type": "file",
+            "path": "Art/Images/Dimmi-Art-Im.txt"
+          }
+        ]
+      },
+      {
         "name": "VKS-Animate.txt.txt",
         "type": "file",
         "path": "Art/VKS-Animate.txt.txt"
@@ -547,5 +558,10 @@ const fileTree = [
     "name": "Start.txt",
     "type": "file",
     "path": "Start.txt"
+  },
+  {
+    "name": "server.js",
+    "type": "file",
+    "path": "server.js"
   }
 ];

--- a/UI/index.html
+++ b/UI/index.html
@@ -10,10 +10,7 @@
   <aside id="sidebar">
     <div id="fileTree"></div>
   </aside>
-  <main id="content">
-    <h1>Welcome to Dimmi Explorer</h1>
-    <p>Select a file from the menu to view its contents or a folder to expand.</p>
-  </main>
+  <main id="content"></main>
   <script src="fileTree.js"></script>
   <script src="summaries.js"></script>
   <script src="ui.js"></script>

--- a/UI/style.css
+++ b/UI/style.css
@@ -64,4 +64,8 @@ body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; 
   border: 1px solid #ccc;
   margin-top: 10px;
 }
+#saveBtn {
+  margin-top: 10px;
+  padding: 6px 12px;
+}
 pre { white-space: pre-wrap; }

--- a/UI/summaries.js
+++ b/UI/summaries.js
@@ -14,6 +14,8 @@ const summaries = {
   "Art/Dimmi-Art-Si.txt": "/// FILE: Dimmi-Art-Si.txt /// VERSION: 4.0.0 /// LAST-UPDATED: 2025-06-15",
   "Art/Dimmi-Art-Vi.txt": "// FILE: Dimmi-Art-Vi.txt /// VERSION: 4.0.0 /// LAST-UPDATED: 2025-06-14",
   "Art/Dimmi-Art.txt": "/// FILE: Dimmi-Art.txt /// VERSION: 4.0.0 /// LAST-UPDATED: 2025-06-15",
+  "Art/Images/Dimmi-Art-Im.txt": "/// FILE: Dimmi-Art-Im.txt /// VERSION: 4.0.0 /// LAST-UPDATED: 2025-06-15",
+  "Art/Images": "Folder containing 1 items.",
   "Art/VKS-Animate.txt.txt": "VKS-Animate.txt Introduction to VKS Animation Aspect The Visual Kinetic Sketching (VKS) style emphasizes capturing the motion and energy of subjects within static imagery. To enhance this dynamic qual",
   "Art/VKS-Deconstruct.txt.txt": "VKS-Deconstruct.txt  econstructing the VKS Style The VKS style revolves around several core principles: Dynamic Lines, Anatomy & Structure, Light Interaction, and Texture & Detail. This file should br",
   "Art/VKS-Feedback.txt.txt": "VKS-Feedback.txt Feedback in the Visual Kinetic Sketching (VKS) process is essential for fine-tuning and ensuring that the AI or artist stays true to the core principles of the style. It involves a co",
@@ -25,7 +27,7 @@ const summaries = {
   "Art/VKS-Refinement.txt.txt": "VKS-Refinement.txt The refinement process in the Visual Kinetic Sketching (VKS) style focuses on elevating the initial image output to achieve a polished, dynamic, and cohesive composition. This proce",
   "Art/VKX-Composition.txt": "VKX-Planning.txt VKS-Composition.txt This file will serve as the blueprint for understanding and structuring the Visual Kinetic Sketching (VKS) style within compositions. Composition refers to how ele",
   "Art/dimmi-art-reconstruction.txt": "/// FILE: dimmi-art-reconstruction.txt /// VERSION: 1.0.0 /// LAST-UPDATED: 2025-08-26",
-  "Art": "Folder containing 16 items.",
+  "Art": "Folder containing 17 items.",
   "Commands/Commands-Analyze.txt": " ### **Commands-Analyze.txt** #### **ANALYZE Command**",
   "Commands/Commands-Deconstruct.txt.txt": "**Commands-Deconstruct.txt** #### **DECONSTRUCT Command** **Purpose**: Disassemble content into raw elements such as words, phrases, and simple ideas. Focuses on structural visibility without analysis",
   "Commands/Commands-Edit.txt": " ### **Commands-Edit.txt** #### **EDIT Command**",
@@ -106,5 +108,6 @@ const summaries = {
   "Older Modules/dimmi-Tactics.txt": "TITLE: Dimmi’s Tactical Playbook: The Art of Waking People Up CATEGORY: Psychological Warfare / Engagement Tactics VERSION: v1.1",
   "Older Modules": "Folder containing 8 items.",
   "README.md": "# dimmi Exploratory prototype for Dimmi. The `UI/index.html` page provides a small \"DIMMI\" widget that slides out a menu of project files.",
-  "Start.txt": "// FILE: Start.txt // VERSION: 4.0.0 // LAST-UPDATED: 2025-06-15"
+  "Start.txt": "// FILE: Start.txt // VERSION: 4.0.0 // LAST-UPDATED: 2025-06-15",
+  "server.js": "const http = require('http'); const fs = require('fs'); const path = require('path');"
 };

--- a/server.js
+++ b/server.js
@@ -1,0 +1,79 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const url = require('url');
+
+const ROOT_DIR = __dirname;
+
+function serveFile(filePath, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = {
+      '.html': 'text/html',
+      '.js': 'application/javascript',
+      '.css': 'text/css',
+      '.txt': 'text/plain',
+    }[ext] || 'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsed = url.parse(req.url, true);
+
+  if (req.method === 'POST' && parsed.pathname === '/save') {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => {
+      try {
+        const { path: filePath, content } = JSON.parse(body);
+        if (!filePath) throw new Error('Missing path');
+        const safePath = path
+          .normalize(filePath)
+          .replace(/^\u0000+/, '')
+          .replace(/^((\.\.\/)+)/, '');
+        const fullPath = path.join(ROOT_DIR, safePath);
+        fs.writeFile(fullPath, content, 'utf8', err => {
+          if (err) {
+            res.writeHead(500);
+            res.end('Error saving file');
+          } else {
+            res.writeHead(200);
+            res.end('Saved');
+          }
+        });
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Bad request');
+      }
+    });
+    return;
+  }
+
+  let filePath = path.join(ROOT_DIR, parsed.pathname);
+  if (parsed.pathname === '/') {
+    filePath = path.join(ROOT_DIR, 'UI/index.html');
+  }
+  fs.stat(filePath, (err, stats) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    if (stats.isDirectory()) {
+      filePath = path.join(filePath, 'index.html');
+    }
+    serveFile(filePath, res);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running at http://localhost:${PORT}/UI/index.html`);
+});


### PR DESCRIPTION
## Summary
- display text file contents directly in the browser with an inline editor and save button
- load `Start.txt` on startup for a Dimmi intro page
- add lightweight Node server to serve files and persist edits

## Testing
- `node UI/generate-file-tree.js`
- `node server.js` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68ae81b5fb64832c994402bb4b987e00