### PR TITLE
Fix file serving paths and add in-browser text editor

### DIFF
--- a/UI/ui.js
+++ b/UI/ui.js
@@ -45,7 +45,7 @@ async function showSummary(path, isFile = false) {
   content.innerHTML = `<h2>${safe(path)}</h2><p class="summary">${safe(summary)}</p>`;
   if (isFile) {
     try {
-      const res = await fetch('../' + encodeURI(path));
+      const res = await fetch('/' + encodeURI(path));
       if (res.ok) {
         const text = await res.text();
         const editor = document.createElement('textarea');

--- a/server.js
+++ b/server.js
@@ -26,8 +26,9 @@ function serveFile(filePath, res) {
 
 const server = http.createServer((req, res) => {
   const parsed = url.parse(req.url, true);
+  let pathname = decodeURIComponent(parsed.pathname);
 
-  if (req.method === 'POST' && parsed.pathname === '/save') {
+  if (req.method === 'POST' && pathname === '/save') {
     let body = '';
     req.on('data', chunk => (body += chunk));
     req.on('end', () => {
@@ -56,10 +57,16 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  let filePath = path.join(ROOT_DIR, parsed.pathname);
-  if (parsed.pathname === '/') {
-    filePath = path.join(ROOT_DIR, 'UI/index.html');
+  if (pathname === '/') {
+    pathname = '/UI/index.html';
   }
+  const safePath = path
+    .normalize(pathname)
+    .replace(/^\u0000+/, '')
+    .replace(/^((\.\.\/)+)/, '')
+    .replace(/^\/+/, '');
+  let filePath = path.join(ROOT_DIR, safePath);
+
   fs.stat(filePath, (err, stats) => {
     if (err) {
       res.writeHead(404);


### PR DESCRIPTION
## Summary
- Sanitize and normalize request paths to serve files from the project directory
- Fetch files via absolute paths and render them in an editable textarea with a save endpoint

## Testing
- `curl -i http://localhost:3000/Start.txt`
- `curl -i -s -X POST http://localhost:3000/save -H "Content-Type: application/json" -d '{"path":"temp_test2.txt","content":"Hello again"}'`
- `curl -i -s http://localhost:3000/temp_test2.txt`


------
https://chatgpt.com/codex/tasks/task_e_68ae84914774832c8a3d5566e3dcc91e