### PR TITLE
Enable inline text file editing in Dimmi UI

### DIFF
--- a/UI/ui.js
+++ b/UI/ui.js
@@ -45,7 +45,7 @@ async function showSummary(path, isFile = false) {
   content.innerHTML = `<h2>${safe(path)}</h2><p class="summary">${safe(summary)}</p>`;
   if (isFile) {
     try {
-      const res = await fetch('/' + encodeURI(path));
+      const res = await fetch('../' + encodeURI(path));
       if (res.ok) {
         const text = await res.text();
         const editor = document.createElement('textarea');
@@ -55,8 +55,13 @@ async function showSummary(path, isFile = false) {
         const saveBtn = document.createElement('button');
         saveBtn.id = 'saveBtn';
         saveBtn.textContent = 'Save';
+        const rawLink = document.createElement('a');
+        rawLink.href = '../' + path;
+        rawLink.textContent = 'Open raw';
+        rawLink.target = '_blank';
         content.appendChild(editor);
         content.appendChild(saveBtn);
+        content.appendChild(rawLink);
         saveBtn.addEventListener('click', async () => {
           const body = JSON.stringify({ path, content: editor.value });
           const resp = await fetch('/save', {


### PR DESCRIPTION
## Summary
- Load text files using paths relative to the UI so content appears when viewing `index.html`
- Add raw file link and maintain save button for editing inside the UI

## Testing
- `node server.js &` (manual verification that server starts)


------
https://chatgpt.com/codex/tasks/task_e_68ae86c4e0dc832c9edc4e1f0f01fe25