### PR TITLE
Add basic Android menu app skeleton

### DIFF
--- a/DOOR/app/build.gradle
+++ b/DOOR/app/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.door'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId "com.example.door"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/DOOR/app/src/main/AndroidManifest.xml
+++ b/DOOR/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application
+        android:label="@string/app_name"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/DOOR/app/src/main/java/com/example/door/MainActivity.kt
+++ b/DOOR/app/src/main/java/com/example/door/MainActivity.kt
@@ -1,0 +1,29 @@
+package com.example.door
+
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_settings -> {
+                Toast.makeText(this, "Settings selected", Toast.LENGTH_SHORT).show()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+}

--- a/DOOR/app/src/main/res/layout/activity_main.xml
+++ b/DOOR/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hello_world"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/DOOR/app/src/main/res/menu/main_menu.xml
+++ b/DOOR/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_settings"
+        android:title="@string/action_settings" />
+</menu>

--- a/DOOR/app/src/main/res/values/strings.xml
+++ b/DOOR/app/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="app_name">DOOR</string>
+    <string name="hello_world">Hello from DOOR</string>
+    <string name="action_settings">Settings</string>
+</resources>

--- a/DOOR/build.gradle
+++ b/DOOR/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.5.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+tasks.register("clean", Delete) {
+    delete(rootProject.buildDir)
+}

--- a/DOOR/settings.gradle
+++ b/DOOR/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "DOOR"
+include(":app")


### PR DESCRIPTION
## Summary
- add DOOR Android project using Kotlin with a simple MainActivity and options menu
- include minimal build.gradle and resources for launching on Android

## Testing
- `gradle tasks --offline` *(fails: Starting a Gradle Daemon, requires Android dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8a5fe76c832c8a99cf05a73b022f