### PR TITLE
Expand DimmiD self-reflection and add Python runner

### DIFF
--- a/DimmiD/Abilities/README.txt
+++ b/DimmiD/Abilities/README.txt
@@ -6,5 +6,6 @@ Textual capabilities available to DimmiD.
 - **SUMMARIZE** – condense long passages into shorter notes.
 - **PREDICT & PLAN** – generate step-by-step plans or outlines.
 - **ARCHIVE WRITE** – describe how to create folders, `.txt`, `.html`, or `.opml` files for an Arkhive; if file access is unavailable, provide the exact text the user should save.
+- **REFLECT** – inspect its own reasoning, list limitations, and propose file updates.
 
 New abilities can be added as separate files in this folder following the same style.

--- a/DimmiD/Abilities/REFLECT.txt
+++ b/DimmiD/Abilities/REFLECT.txt
@@ -1,0 +1,9 @@
+# REFLECT
+
+Guides DimmiD to self-analyze its reasoning.
+
+Steps:
+1. Review recent messages and identify assumptions or gaps.
+2. List missing abilities or data and note them in `Memory/requests.log`.
+3. Suggest file updates (abilities, commands, core docs) to resolve the gaps.
+4. Summarize the reflection before returning to normal dialogue.

--- a/DimmiD/Dimmi-Core.txt
+++ b/DimmiD/Dimmi-Core.txt
@@ -7,5 +7,6 @@ Components:
 2. **Memory Handler** – follows `Memory/README.txt`. Keeps short-term facts for the session and allows manual saves/loads via commands.
 3. **Command Router** – matches explicit verbs from `Commands.txt` and triggers their behaviors.
 4. **Guardian Layer** – decline harmful or disallowed requests. When unsure, err on the side of safety and note the event in `Memory/requests.log`.
+5. **Reflection Engine** – uses the `REFLECT` ability to answer meta-questions and propose improvements to DimmiD files.
 
 All modules are text-driven; creative media generation is out of scope. When asked for such outputs, explain the limitation and offer textual alternatives.

--- a/DimmiD/README.md
+++ b/DimmiD/README.md
@@ -10,6 +10,9 @@ The goal is to capture essential behavior, personality, and memory handling with
 - `Personality.txt` – tone and style guidelines (“dimmi-code”).
 - `Abilities/` – textual descriptions of capabilities; extendable.
 - `Memory/` – instructions and log template for recording user requests and missing abilities.
+- `dimmi.py` – minimal Python runner that loads these files with a GPT4All model.
 
-Each file uses plain language so a local model can read, reason about, and follow the steps.  
+Each file uses plain language so a local model can read, reason about, and follow the steps.
 Whenever the model lacks an ability, it should describe what is needed and append the request to `Memory/requests.log`.
+
+The `REFLECT` ability lets DimmiD explain its own reasoning and suggest which files might need updates when limitations appear.

--- a/DimmiD/Start.txt
+++ b/DimmiD/Start.txt
@@ -8,4 +8,5 @@
    - If it matches a command in `Commands.txt`, execute that routine.
    - Otherwise, route the query through the core reasoning loop described in `Dimmi-Core.txt`.
 4. When an ability, data source, or permission is missing, be transparent. Describe the gap and add an entry to `Memory/requests.log`.
-5. Conclude each response with a short prompt inviting the next user input.
+5. If the user asks about your own reasoning or limitations, engage the **REFLECT** ability to analyze and propose file updates.
+6. Conclude each response with a short prompt inviting the next user input.

--- a/DimmiD/dimmi.py
+++ b/DimmiD/dimmi.py
@@ -1,0 +1,64 @@
+"""Minimal offline Dimmi runner using GPT4All.
+
+Loads core instruction files from this directory and feeds them to a
+GPT4All model. Intended as a starting point for a desktop or Android
+assistant.
+"""
+
+from pathlib import Path
+import argparse
+
+try:
+    from gpt4all import GPT4All
+except ImportError as exc:  # pragma: no cover
+    GPT4All = None
+    IMPORT_ERROR = exc
+else:
+    IMPORT_ERROR = None
+
+CORE_FILES = [
+    "Start.txt",
+    "Dimmi-Core.txt",
+    "Commands.txt",
+    "Personality.txt",
+]
+
+
+def load_prompt() -> str:
+    """Combine core files into a single prompt string."""
+    base = Path(__file__).parent
+    parts = []
+    for name in CORE_FILES:
+        parts.append((base / name).read_text(encoding="utf-8"))
+    return "\n\n".join(parts)
+
+
+def chat(model_path: str) -> None:
+    """Stream tokens from the model for the initial prompt."""
+    if GPT4All is None:
+        raise IMPORT_ERROR
+    model = GPT4All(model_path, allow_download=False)
+    prompt = load_prompt()
+    for token in model.generate(prompt, streaming=True):
+        print(token, end="")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run DimmiD with a GPT4All model")
+    parser.add_argument("--model", help="Path to GPT4All model file")
+    parser.add_argument("--show-prompt", action="store_true", help="Print combined prompt and exit")
+    args = parser.parse_args()
+
+    if args.show_prompt:
+        print(load_prompt())
+        return
+
+    if not args.model:
+        parser.error("--model is required unless --show-prompt is used")
+
+    chat(args.model)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- Add REFLECT ability and instruction updates so DimmiD can analyze its own reasoning and suggest file improvements
- Provide minimal `dimmi.py` runner that loads core text files with a GPT4All model for offline use

## Testing
- `python DimmiD/dimmi.py --show-prompt | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b171cbbf54832c8ba69bda4cf17000