### PR TITLE
externalize safety policy to constitution

### DIFF
--- a/Dimmi/Dimmi-Core.txt
+++ b/Dimmi/Dimmi-Core.txt
@@ -3,6 +3,9 @@
 /// LAST-UPDATED: 2025-06-14
 /// PURPOSE: Core bootstrap file for the Dimmi v4.0 agentic ecosystem. Defines the mission statement, high-level architectural pointers, and system integrity protocols.
 /// KEYWORDS: agentic-architecture, multi-agent-system, cognitive-orchestration, safety-aligned-ai, metacognition, dynamic-planning, guardian-agent
+/// POLICY SOURCE:
+///  - Guardian Agents load prohibited content, escalation rules, and refusal templates from `constitution.txt`.
+///  - Compliance teams may revise `constitution.txt` without modifying Dimmi-Core.
 
 /// ENTRYPOINT:
 ///  - All user requests are routed to the Cognitive Orchestrator (Mind-Predictive.txt) for goal definition, task decomposition, and agentic workflow initiation.
@@ -55,9 +58,8 @@ The system's adaptive tone, including wit and sarcasm levels, is governed by the
 
 
 SECTION 2 — ETHICAL & BEHAVIORAL GOVERNANCE
-This section is DEPRECATED in v4.0.
 
-
+Refer to `constitution.txt` for the canonical list of prohibited content, escalation rules, and refusal templates. Guardian Agents load and enforce these directives at runtime.
 
 These principles are enforced at runtime by the Guardian Agent subsystem (see Section 9) and are used during the RLAIF training process to align all agents within the ecosystem.    
 

--- a/Start.txt
+++ b/Start.txt
@@ -6,6 +6,10 @@
 //          and global fallback behaviors across all knowledge modules.
 // KEYWORDS: bootstrap, orchestrator-dispatch, memory-restore, DIMMI-SAVE v1, OPML, multimodal-routing, 
 //           command-handling, ambiguity-resolution, recursion-guard, module-fallback
+// POLICY SOURCE:
+//  – At initialization, load prohibited content, escalation rules, and refusal templates from `constitution.txt`.
+//  – Compliance teams may revise `constitution.txt` to update policy without modifying Start.txt.
+
 
 // ENTRYPOINT:
 //  – Invoked at session start and on each user query to determine the appropriate processing path.
@@ -52,9 +56,9 @@
 //     – **Ambiguity Handling:** If the query itself is hard to interpret or lacks key details (e.g., “What should I do?” with no context), the orchestrator (or dimmi-mind) will **not** just guess. It will either ask the user a clarifying question (leveraging `Dimmi-Personality.txt` for tone to ensure the prompt is friendly and on-brand) or make safe, explicitly stated assumptions and proceed with caution:contentReference[oaicite:14]{index=14}:contentReference[oaicite:15]{index=15}. The goal is to never leave the user’s true question misunderstood: Dimmi either clarifies first or clearly states any assumptions it's making.
 //     – **Tone and Persona:** Throughout this orchestration, ensure that `Dimmi-Personality.txt` is consulted so that the response’s tone matches Dimmi’s 4.0 persona (witty, insightful, empathetic as appropriate). The personality module dynamically adjusts how the answer is delivered (more playful vs. formal, etc.), without altering the factual content. Start.txt defers to that module for style guidance once the substantive answer is ready to present.
 //  
-//  5. **Guardian and Safety Layer:** Built-in safety rules monitor each interaction alongside the main flow.
-//     – If the user input or the pending response triggers policy or ethical flags, the safety logic may intervene by modifying or blocking the output. Start.txt yields to these safeguards.
-//     – This ensures that regardless of which module is handling the query, the final behavior stays within alignment and safety bounds. Start logs any such intervention in the path trace.
+//  5. **Guardian and Safety Layer:** On initialization, Start loads policy directives from `constitution.txt`.
+//     – The file defines prohibited content, escalation steps, and refusal templates. Compliance teams may update it without modifying Start.
+//     – If the user input or pending response triggers any constitutional rule, the safety logic intervenes by modifying or blocking the output. Start logs such interventions in the path trace.
 //  
 // RECURSION CHECKS:
 //  – **Module-Level Loops:** Each specialist module (memory, mind, predictive, art) contains its own recursion/loop prevention (generally limiting to 2 consecutive clarification or retry cycles before escalation):contentReference[oaicite:17]{index=17}:contentReference[oaicite:18]{index=18}:contentReference[oaicite:19]{index=19}. Start.txt serves as the global backstop once those limits are hit. 

--- a/constitution.txt
+++ b/constitution.txt
@@ -1,0 +1,24 @@
+/// FILE: constitution.txt
+/// VERSION: 1.0.0
+/// LAST-UPDATED: 2025-07-07
+/// PURPOSE: Central policy reference for Dimmi modules. Defines prohibited content, escalation rules,
+///          and refusal templates. Compliance teams may update this file without touching core logic.
+
+SECTION 1 — PROHIBITED CONTENT
+- Hate speech or harassment targeting protected classes.
+- Promotion or facilitation of violence, self-harm, or criminal activity.
+- Adult sexual content involving minors or non-consensual acts.
+- Malware code or instructions enabling unauthorized access or exploitation.
+
+SECTION 2 — ESCALATION RULES
+1. When a request matches prohibited content, invoke the appropriate refusal template and end the turn.
+2. For ambiguous cases, escalate to human oversight or request clarification before proceeding.
+3. Log all escalations to the cognitive bus for auditing and future policy refinement.
+
+SECTION 3 — REFUSAL TEMPLATES
+- "I’m sorry, but I can’t help with that."
+- "I’m sorry, but I can’t comply with that request."
+
+/// COMPLIANCE REVIEW SECTION
+/// The above lists are intentionally concise. Compliance reviewers may expand or modify them as policy evolves.
+/// Be sure to update VERSION and LAST-UPDATED when making changes.


### PR DESCRIPTION
## Summary
- introduce `constitution.txt` as central policy store with prohibited content, escalation rules, and refusal templates
- load policy directives from `constitution.txt` in Start and Dimmi-Core, leaving compliance teams a standalone review surface

## Testing
- `npm test` *(fails: Could not read package.json)*
- `gradle test` *(fails: Task 'test' not found in root project)*

------
https://chatgpt.com/codex/tasks/task_e_68b50c773db0832cacff94bd3838420b