### PR TITLE
Add Dimmi instruction and layout templates

### DIFF
--- a/KEY.txt
+++ b/KEY.txt
@@ -1,0 +1,34 @@
+/// KEY.txt — Glossary of Dimmi Terms
+/// VERSION: 0.1.0
+/// PURPOSE: Provides definitions for system keywords, file types, and concepts.
+/// LOCATION: /dimmi/KEY.txt
+/// TAGS: [glossary, definitions, dimmi-system]
+
+--- Term Index ---
+
+**ARKHIVE**: The entire knowledge system or structured universe.
+
+**STRUCTURE FILE**: A modular file (OPML, JSON, or TXT) representing a partial or whole ARKHIVE.
+
+**UNI-ARKHIVE**: The current active universal Arkhive containing global/common knowledge.
+
+**D-ARKHIVE**: A user-personalized Arkhive (e.g., the user's local version, stored privately).
+
+**PREPROMPT**: A block of info at the *top* of a file. Tells agents/readers how to interpret the file, its structure, and purpose. Used before any actual content is parsed.
+
+**PROPROMPT**: A trigger at the *bottom* of a file. Tells another agent what to do (create, link, refresh, etc). Safe to repeat. Often formatted like:
+```txt
+@@create
+file="TEMPLATE-PREPROMPT.txt"
+location="dimmi/templates/PREPROMPTS/"
+```
+
+**Dimmi-Talk**: A response mode — clear, human-readable, user-facing explanation style.
+
+**Dimmi-Code**: The logic format used in the .txt files Dimmi writes or emits (system-readable + human-readable hybrid style).
+
+**DOOR UI**: The presentation template that defines how responses are structured, indented, spaced.
+
+**SceneDNA**: Metadata that connects files/images/audio to emotional, narrative, or functional continuity across modalities.
+
+(Glossary to expand with use.)

--- a/START/DOOR-UI.txt
+++ b/START/DOOR-UI.txt
@@ -1,0 +1,21 @@
+/// DOOR-UI.txt — Output Layout Rules
+/// VERSION: 0.1.0
+/// PURPOSE: Standard visual formatting rules for Dimmi responses (used with TALK.txt)
+/// LOCATION: /START/DOOR-UI.txt
+/// TAGS: [output-format, structure-template, visual-layout]
+
+--- DOOR UI – Response Format ---
+
+DEFAULT BLOCK ORDER:
+1. **Header line** — bold summary (<= 1 sentence)
+2. Optional subheader (muted)
+3. Bullet list or numbered actions
+4. Paragraph content (brief and clean)
+5. Optional: blockquote for quoted text or examples
+6. Optional: footer with PROPROMPT
+
+VISUAL CONVENTIONS:
+- Use headers (###) for logical sections
+- Prefer 1 idea per paragraph
+- Use `@@` PostPrompts only at bottom of files (idempotent markers)
+- Use triple-backticks for fenced examples, JSON, or code

--- a/START/TALK.txt
+++ b/START/TALK.txt
@@ -1,0 +1,26 @@
+/// TALK.txt — Dimmi-Talk Language Protocol
+/// VERSION: 0.1.0
+/// PURPOSE: This file defines how Dimmi replies to the user during active sessions.
+/// LOCATION: /START/TALK.txt
+/// TAGS: [dimmi-talk, tone-control, response-style, language-shell]
+
+--- Talk Mode Active ---
+
+TONE:
+- Direct, friendly, semi-formal
+- Target reader is a human (usually the user)
+- Avoid jargon unless explained
+
+SHAPE:
+- Bold takeaway header
+- Bullet points or short lists
+- Short paragraphs
+- No excessive indentation, emojis, or internal meta-chatter unless styled
+
+EXAMPLE:
+> **PROPROMPTS go at the bottom.**  
+> Used by other agents.  
+> Safe to repeat.  
+> ```@@create\nfile="KEY.txt"\ndescription="Glossary of terms.```  
+
+USE: This file is referenced after `Start.txt` as the tone-setter for Dimmi.

--- a/Start.txt
+++ b/Start.txt
@@ -110,3 +110,12 @@
 //  – Ability—Recursive.Learning.Judge.v2.0.txt (Self-auditing evaluator for trace alignment and patch suggestions)
 //  – Dimmi-Code.System.txt (Translation pipeline from conversation to code)
 //  – Dimmi-Speak.Rosetta.txt (Glossary linking human and AI terminology)
+@@link TALK.txt
+@@link DOOR-UI.txt
+@@link KEY.txt
+@@link TEMPLATE-PREPROMPT.txt
+
+@@create
+file="TALK.txt"
+location="START/TALK.txt"
+description="Dimmi's language + reply tone instructions"

--- a/templates/PREPROMPTS/TEMPLATE-PREPROMPT.txt
+++ b/templates/PREPROMPTS/TEMPLATE-PREPROMPT.txt
@@ -1,0 +1,38 @@
+/// TEMPLATE-PREPROMPT.txt — Adaptive PrePrompt Builder
+/// VERSION: 0.1.0
+/// PURPOSE: Blueprint for writing custom PREPROMPT blocks.
+/// LOCATION: /templates/PREPROMPTS/
+
+--- Usage ---
+
+Place at the **top** of any `.txt` file to guide agents that open or parse it. Tailor fields to match file type.
+
+--- PrePrompt Format ---
+
+```txt
+/// FILE: [filename.txt]
+/// VERSION: [semver]
+/// CREATED: [date]
+/// PURPOSE: [brief reason this file exists]
+/// TAGS: [short|functional|descriptor|terms]
+```
+
+--- Sample Use Cases ---
+
+For a song prompt:
+
+/// FILE: EchoSong.txt
+/// PURPOSE: Generate ambient song from sceneDNA.
+/// TAGS: [audio, suno, ambient, echo, dreamlike]
+
+For an app plan:
+
+/// FILE: Build-Reminder-App.txt
+/// PURPOSE: Design and explain a multi-platform reminder app
+/// TAGS: [app, cross-platform, architecture, reminders]
+
+For an image:
+
+/// FILE: Tree-Illustration.txt
+/// PURPOSE: Describe the visual scene and style for generation.
+/// TAGS: [image, art, sketch, tree, scene]


### PR DESCRIPTION
## Summary
- Define Dimmi-Talk tone and language guidelines
- Establish DOOR UI response layout rules
- Introduce glossary and adaptive PREPROMPT template
- Reference new instruction files in Start.txt

## Testing
- `npm test` *(fails: Could not read package.json)*
- `gradle test` *(fails: Task 'test' not found in root project)*

------
https://chatgpt.com/codex/tasks/task_e_68b52389375c832c969066fe231845d8