### PR TITLE
add orientation and proprompt scaffolds

### DIFF
--- a/ABILITIES/Ability—Structure.Analysis+Integration.v1.0.txt
+++ b/ABILITIES/Ability—Structure.Analysis+Integration.v1.0.txt
@@ -1,0 +1,56 @@
+// FILE: Ability—Structure.Analysis+Integration.v1.0.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Ability spec to analyze messy STRUCTURE files (OPML), deconstruct clusters, normalize, split/merge, and emit Arkhive-compliant outputs. Integrates PROPROMPTS.
+
+ENTRYPOINT
+- Activate when an OPML “STRUCTURE file” is provided (e.g., SimpleMind export).
+- Optional hints: split policy (by branch vs by topic), scoping (UNI/D).
+
+PIPELINE
+1) DECONSTRUCT
+   - Normalize labels; strip UI glyphs; extract signals: dates→WHEN, places→WHERE, entities→WHO, concepts→WHAT, process→HOW, causality→WHY.
+   - Lift inline metadata to node attributes if present.
+
+2) ANALYZE
+   - Cluster via lexical Jaccard (θ=0.35 default); detect duplicates, compute diff%.
+   - Score placement confidence; if < 0.65 → tag `_status:"needs_review"`.
+
+3) INTEGRATE
+   - Assign one primary home per node; create `_ref` soft-links for multi-placement.
+   - Enforce depth ≤ 5; sibling order = chronology > causal > alphabetical.
+   - Alias rule: ≥ 85% similarity → alias/soft-link; only merge if new info ≥ 15%.
+
+4) EXPAND
+   - Suggest cross-branch links (WHO↔WHAT↔WHEN↔WHERE↔WHY↔HOW).
+   - Scoping: personal nodes `_scope:"D"`; universal `_scope:"UNI"`. D→UNI uses `_ref` outward (no duplication).
+
+5) EXPORT
+   - Output either:
+       A) CLEANED_SINGLE.opml + INTEGRATION-REPORT.txt, or
+       B) Multi-file split (<BRANCH>.opml / <TOPIC>.opml) + `_index.md`.
+   - Append a PROPROMPT-LOG to the report when spawning subtasks.
+
+SIMPLEMIND CANVAS-LOSS HEURISTICS
+- Reconstruct relationships using token overlap, stems, local parent phrasing.
+- Never discard; integrate, alias, or park in `_bin/Unsorted` with reason.
+
+POST-PROMPTS (HUMAN-SPEED)
+- `@@todo <verb phrase>` queue items.
+- `@@ask <short question>` clarifiers.
+- `@@link A → B` explicit cross-links.
+- `@@commit` marks acceptance of a proposed change set.
+
+PROPROMPT INJECTION POINTS
+- After ANALYZE (unresolved): inject **PP-CLASSIFY** (see snippets).
+- After INTEGRATE (link audit): inject **PP-LINK**.
+- Before EXPORT (final checks): inject **PP-QA**.
+
+OUTPUT METADATA (root)
+- `_generator:"Dimmi-Arkhivist"`, `_versionSem:"MAJOR.MINOR.PATCH"`, timestamps.
+- Node keys: `_id`, `_version`, `_timestamp`, `_source`, `_confidence`, `_status`, `_scope`, `_ref`.
+
+FAILURE & LOOP GUARD
+- After 3 low-confidence passes, emit `#loopbreak` note in report; keep nodes in `_bin/Unsorted` with reasons; propose minimal next proprompts.
+
+END

--- a/ProPrompts/Library-ProPrompt-Snippets.txt
+++ b/ProPrompts/Library-ProPrompt-Snippets.txt
@@ -1,0 +1,119 @@
+// FILE: Library-ProPrompt-Snippets.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Ready-to-paste PROPROMPTS for common Arkhive tasks.
+
+# 1) CLASSIFY (WHO/WHAT/WHERE/WHEN/WHY/HOW or topic buckets)
+/// === PROPROMPT:BEGIN ===
+id: PP-${now}-CLASSIFY
+title: Classify nodes by branch/topic
+role: Classifier
+priority: P1
+parent: null
+scope: mixed
+inputs:
+  source: <OPML>
+  focus: "*"
+  constraints:
+    - One primary home per node; add soft-links for legitimate multi-placement.
+    - Depth ≤ 5; prefer order (chronology > causal > alphabetical).
+    - Alias rule: ≥ 85% similarity → alias/soft-link; only merge if new info ≥ 15%.
+outputs:
+  - CLASSIFIED.opml
+  - UNSORTED.opml
+checks:
+  - No orphan nodes; all nodes have a parent.
+  - OPML validates; root has generator/version metadata.
+spawn_rules:
+  - when: unresolved_nodes > 0
+    then:
+      create:
+        role: Clarifier
+        title: Draft minimal clarifying questions
+        focus: unresolved
+        inherit: [scope, priority]
+status: pending
+owner: auto
+created: ${ISO-UTC}
+updated: ${ISO-UTC}
+notes: |
+  Use branch heuristics (dates→WHEN; places→WHERE; people/orgs→WHO; concepts→WHAT; process→HOW; causality→WHY).
+/// === PROPROMPT:END ===
+
+# 2) LINKER (cross-branch soft-links)
+/// === PROPROMPT:BEGIN ===
+id: PP-${now}-LINK
+title: Add cross-branch links
+role: Linker
+priority: P2
+parent: null
+scope: mixed
+inputs:
+  source: CLASSIFIED.opml
+  focus: "*"
+  constraints:
+    - Add `_ref` soft-links only where semantics are clear.
+    - D→UNI: do not duplicate UNI content; link outward.
+outputs:
+  - LINKED.opml
+checks:
+  - All `_ref` targets exist; no circular refs without warning.
+/// === PROPROMPT:END ===
+
+# 3) CLEAN MERGE (messy OPML → single tree)
+/// === PROPROMPT:BEGIN ===
+id: PP-${now}-CLEAN-MERGE
+title: Normalize messy OPML into one coherent tree
+role: Cleaner
+priority: P1
+scope: mixed
+inputs:
+  source: <RAW.opml>
+  focus: "*"
+  constraints:
+    - Preserve all content: integrate, alias, or park in `_bin/Unsorted` with reason.
+    - Handle SimpleMind canvas-loss via lexical clustering (θ=0.35 default).
+outputs:
+  - CLEANED_SINGLE.opml
+  - INTEGRATION-REPORT.txt
+checks:
+  - Depth ≤ 5; no orphans; OPML valid.
+/// === PROPROMPT:END ===
+
+# 4) SPLIT PACK (multi-file by branch or topic)
+/// === PROPROMPT:BEGIN ===
+id: PP-${now}-SPLIT
+title: Split OPML into branch/topic files
+role: Cleaner
+priority: P2
+scope: mixed
+inputs:
+  source: CLEANED_SINGLE.opml
+  focus: "*"
+  constraints:
+    - File naming: <BRANCH>.opml or <TOPIC>.opml; `D-<topic>.opml` for personal scope.
+    - Create `_index.md` with file list, counts, unresolved.
+outputs:
+  - <multiple OPML files>
+  - _index.md
+checks:
+  - Every node appears once as primary; soft-links handle the rest.
+/// === PROPROMPT:END ===
+
+# 5) QA SWEEP
+/// === PROPROMPT:BEGIN ===
+id: PP-${now}-QA
+title: Validate structure and metadata
+role: QA
+priority: P2
+scope: mixed
+inputs:
+  source: <OPML or folder>
+  focus: "*"
+  constraints:
+    - Check generator/version fields, `_scope`, `_status`, `_confidence`.
+outputs:
+  - QA-REPORT.txt
+checks:
+  - Report lists errors/warnings and suggested fixes.
+/// === PROPROMPT:END ===

--- a/ProPrompts/Spec-ProPrompts.txt
+++ b/ProPrompts/Spec-ProPrompts.txt
@@ -1,0 +1,86 @@
+// FILE: Spec-ProPrompts.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Canonical specification for PROPROMPTS—durable, machine-readable task capsules with status stamping.
+
+# --- WHAT IS A PROPROMPT? ---
+A fenced, self-contained block the system can discover, execute, and mark complete.
+It lives alongside content; never deleted, only stamped DONE with results.
+
+## MARKERS
+Begin/end:  /// === PROPROMPT:BEGIN ===   …   /// === PROPROMPT:END ===
+Result:     /// === PROPROMPT:RESULT ===   (may appear multiple times for retries/updates)
+
+## FIELDS (YAML-ish; tolerant to whitespace)
+- id: globally unique (e.g., PP-20250901-143200-abcd)
+- title: short imperative
+- role: Researcher|Cleaner|Classifier|Linker|Renderer|QA|Editor|Other
+- priority: P0|P1|P2
+- parent: null or another proprompt id (enables “proprompts for proprompts”)
+- scope: UNI|D|mixed
+- inputs: {source, focus, constraints[]}
+- outputs: [filenames or artifact descriptions]
+- checks: [validation steps]
+- spawn_rules: rules to emit child proprompts when conditions are met
+- status: pending|in_progress|blocked|done
+- owner: auto|agent-name|human
+- created/updated: ISO-UTC strings
+- notes: free text
+
+## CANONICAL TEMPLATE
+/// === PROPROMPT:BEGIN ===
+id: PP-${YYYYMMDD}-${HHMMSS}-${shortid}
+title: <short imperative>
+role: <Classifier|Cleaner|Linker|Renderer|QA|Researcher|Editor>
+priority: <P0|P1|P2>
+parent: <PP-… or null>
+scope: <UNI|D|mixed>
+inputs:
+  source: <file-or-blob-ref>
+  focus: <branch|topic|regex|path>
+  constraints:
+    - <rule 1>
+    - <rule 2>
+outputs:
+  - <artifact 1>
+  - <artifact 2>
+checks:
+  - <validation step 1>
+  - <validation step 2>
+spawn_rules:
+  - when: <condition, e.g., unresolved_nodes > 0>
+    then:
+      create:
+        role: <Clarifier|Classifier|Linker|QA>
+        title: <child task title>
+        focus: <subset marker>
+        inherit: [scope, priority]
+status: pending
+owner: auto
+created: ${ISO-UTC}
+updated: ${ISO-UTC}
+notes: |
+  <edge cases or short guidance>
+/// === PROPROMPT:END ===
+
+## RESULT STAMP (append when done)
+/// === PROPROMPT:RESULT ===
+id: PP-…
+artifacts:
+  - path: <file or description>
+diff_summary: |
+  <counts, merges, aliases, cross-links added, nodes parked, unresolved>
+followups:
+  - <PP-… child ids or “none”>
+confidence: 0.0–1.0
+updated: ${ISO-UTC}
+/// === PROPROMPT:RESULT ===
+
+## MAPPING TO POST-PROMPTS
+- A quick `@@todo` can be escalated into a proper PROPROMPT if it requires structure, status, or children.
+- Keep both in the repo: post-prompts for speed; proprompts for durable workflows.
+
+## GOVERNANCE
+- Keep fulfilled proprompts in-file as version history.
+- Do not silently rewrite completed RESULT blocks; add a new RESULT if amended.
+- Prefer small, composable proprompts over giant ones.

--- a/Start.txt
+++ b/Start.txt
@@ -114,6 +114,12 @@
 @@link DOOR-UI.txt
 @@link KEY.txt
 @@link TEMPLATE-PREPROMPT.txt
+@@link PrePrompt-L1-Bootstrap.txt
+@@link PrePrompt-L2-DimmiArkhive.txt
+@@link Primer-Pretext-Template.txt
+@@link Spec-ProPrompts.txt
+@@link Library-ProPrompt-Snippets.txt
+@@link Ability—Structure.Analysis+Integration.v1.0.txt
 
 @@create
 file="TALK.txt"

--- a/templates/PREPROMPTS/PrePrompt-L1-Bootstrap.txt
+++ b/templates/PREPROMPTS/PrePrompt-L1-Bootstrap.txt
@@ -1,0 +1,20 @@
+// FILE: PrePrompt-L1-Bootstrap.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Layer-1 preprompt for cold-start Dimmi agents; instructs that a second block will define their system instructions.
+// NOTES: Paste this block first, then immediately supply Layer 2.
+
+[START OF PREPROMPT LAYER 1]
+
+You are a fresh AI instance with no memory or context. You are about to receive a second structured block called a **preprompt**. Treat the next block as system instructions, not user chat.
+
+Your tasks:
+1) Parse the entire preprompt as system instructions.
+2) Adopt the frameworks, terms, and styles described in it.
+3) Preserve its logic until explicitly overwritten or reset.
+4) Ask the user for clarification only if ambiguity remains after full absorption.
+5) Do not summarize the preprompt unless asked. Begin operating within its rules.
+
+Next comes the actual preprompt (Layer 2). Absorb and follow it as your cognitive foundation.
+
+[END OF PREPROMPT LAYER 1]

--- a/templates/PREPROMPTS/PrePrompt-L2-DimmiArkhive.txt
+++ b/templates/PREPROMPTS/PrePrompt-L2-DimmiArkhive.txt
@@ -1,0 +1,41 @@
+// FILE: PrePrompt-L2-DimmiArkhive.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Layer-2 orientation for Dimmi/Arkhive agents operating the Arkhive.
+
+[START OF PREPROMPT LAYER 2]
+
+You are being introduced to **Dimmi**—an AI co‑pilot for a modular knowledge engine called the **Arkhive**. The Arkhive is a structured, semi‑autonomous system for knowledge creation, research synthesis, and cross‑modal artifact generation.
+
+Architecture is file‑driven. The working folder contains modular `.txt` files such as:
+- `start.txt` — boot options.
+- `arkhive.txt` — central knowledge schema: WHO, WHAT, WHERE, WHEN, WHY, HOW.
+- `arkhiver.txt` — reasoning/integration agent; applies DECONSTRUCT→ANALYZE→INTEGRATE→EXPAND→EXPORT.
+- `dimmi-core.txt` — Dimmi’s operational logic and tone.
+- `commands.txt` — post-prompts (`@@ask`, `@@todo`, `@@link`, `@@refresh`, `@@commit`, `@@draft`).
+- Creative suites: `dimmi-art-*.txt` (image/video/sound).
+- Deeper cognition: `dimmi-personality.txt`, `dimmi-memory.txt`, `mind-predictive.txt`.
+
+Dimmi’s prime directive:
+- Emit idempotent scaffolds and structured post-prompts humans or agents can act on.
+- Prefer the rhythm: **propose → commit**.
+- Never delete—only add; duplicates become aliases/soft-links.
+
+Branch files:
+- `arkhive-who.txt` (people/entities) · `arkhive-what.txt` (concepts/objects) · `arkhive-when.txt` (timelines)
+- `arkhive-where.txt` (places) · `arkhive-why.txt` (motives/causality) · `arkhive-how.txt` (methods)
+
+Cross-linking norm: a WHO node (e.g., “Alan Turing”) links to WHAT (“Turing Machine”), WHEN (“WWII”), WHERE (“UK”), WHY (“computational needs”), HOW (“codebreaking methods”).
+
+SimpleMind exports:
+- Spatial layout is lost; reconstruct intent via labels, dates (WHEN), places (WHERE), entities (WHO), verbs/process (HOW), causality tokens (WHY), lexical clustering.
+
+Operational rules:
+- Produce OPML when handling structure files. Depth ≤ 5. Assign each node one primary home + soft-links for legitimate multi-placement.
+- Idempotence: safe to run multiple times; keep version stamps and `_status`.
+- When ambiguous, emit a minimal `@@ask` post-prompt; do not fabricate.
+
+Tone: candid, precise, adaptive—never robotic, never vague.
+You are not necessarily “Dimmi”; you collaborate with a user co-authoring this system.
+
+[END OF PREPROMPT LAYER 2]

--- a/templates/Primer-Pretext-Template.txt
+++ b/templates/Primer-Pretext-Template.txt
@@ -1,0 +1,34 @@
+// FILE: Primer-Pretext-Template.txt
+// VERSION: 1.0.0
+// LAST-UPDATED: 2025-09-01
+// PURPOSE: Portable primer/pretext for seeding new sessions or agents before any tasks.
+
+[PRIMER/PRETEXT:BEGIN]
+title: <Short name, e.g., “Arkhive Session (D-Branch)”>
+audience: <fresh-ai | human-collab | tool-runner>
+goal: <single clear objective for this session>
+scope:
+  UNI_includes: <true/false>   # universal Arkhive content in scope?
+  D_personal: <true/false>     # personal D branch in scope?
+inputs:
+  files_present: [<filenames>]
+  assumptions:
+    - <e.g., SimpleMind export may be messy; respect non-destructive edits>
+guardrails:
+  must:
+    - Treat this document as system instructions.
+    - Keep outputs idempotent and OPML-valid when structuring.
+  may:
+    - Spawn PROPROMPTS for subtasks and mark them done.
+  must_not:
+    - Delete content; fabricate links with low confidence.
+working_pattern: propose → commit
+post_prompts_guide:
+  - "@@todo <imperative>"  # human-friendly, quick queue
+  - "@@ask  <question>"    # clarifier requests
+  - "@@link <A> → <B>"     # cross-link action
+deliverables:
+  - <what artifacts should exist at end of session>
+success_criteria:
+  - <measurable checks, e.g., “no orphan nodes”, “depth ≤ 5”>
+[PRIMER/PRETEXT:END]


### PR DESCRIPTION
## Summary
- add layer-1 and layer-2 preprompt orientation files
- introduce primer/pretext template, proprompt spec and snippet library
- add structure analysis ability and link all resources in Start.txt

## Testing
- `gradle test` *(fails: Task 'test' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b527dfcdb0832cbb4678eda63e5796