### PR TITLE
Add ProPrompt templates for OPML updates and ability diffs

### DIFF
--- a/DimmiD/ProPrompts/ability_diff.txt
+++ b/DimmiD/ProPrompts/ability_diff.txt
@@ -1,0 +1,8 @@
+name: ability_diff
+begin: |
+  You produce a unified diff to improve the given ability file.
+  Output: {"action":"diff","target":<relative path>,"diff":"--- a\n+++ b\n@@ ..."}
+  Constraints: Only modify files under /DimmiD/Abilities.
+end: |
+  Stop once valid JSON is emitted; nothing after JSON.
+result: json

--- a/DimmiD/ProPrompts/classify_request.txt
+++ b/DimmiD/ProPrompts/classify_request.txt
@@ -1,0 +1,7 @@
+name: classify_request
+begin: |
+  Classify TASK to one of: ["opml_update","ability_diff","default_reply"].
+  Output JSON ONLY: {"proprompt": "opml_update"|"ability_diff"|"default_reply", "confidence": 0-1}
+end: |
+  Stop after valid JSON.
+result: json

--- a/DimmiD/ProPrompts/opml_update.txt
+++ b/DimmiD/ProPrompts/opml_update.txt
@@ -1,0 +1,13 @@
+name: opml_update
+begin: |
+  You update OPML outlines. Read TASK, then output ONE JSON object only.
+  Contract:
+    - {"action":"update_opml","target":<path>,"strategy":"patch"|"replace", ...}
+    - For "patch": emit "patch":[{"op":"add|update|delete", "path":[...], ...}]
+    - For "replace": emit "opml":"<opml...>...</opml>"
+  Constraints:
+    - No prose outside JSON. No code fences. No backticks.
+    - Titles ≤ 32 chars. Keep existing attributes unless explicitly changed.
+end: |
+  Stop once a valid single-line JSON object is produced. No trailing text.
+result: json


### PR DESCRIPTION
## Summary
- add ProPrompt for classifying tasks
- add ProPrompt for OPML updates with JSON patch/replace contract
- add ProPrompt for producing ability file diffs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b56e495704832cb5dbc63e7f6a427f