### PR TITLE
Add modular app template root with shared menu system

### DIFF
--- a/ModularRoot/.gitignore
+++ b/ModularRoot/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/ModularRoot/Arkhive/NOTES.txt
+++ b/ModularRoot/Arkhive/NOTES.txt
@@ -1,0 +1,3 @@
+This arkhive explores a modular architecture for Dimmi apps.
+Each module registers itself with a shared menu system.
+New apps can be added by creating a module with a `register(menu)` function.

--- a/ModularRoot/Arkhive/main.py
+++ b/ModularRoot/Arkhive/main.py
@@ -1,0 +1,21 @@
+"""Prototype entry point combining modular apps with a shared menu."""
+from shared.menu import Menu
+from modules import text_editor, image_viewer
+
+MODULES = [text_editor, image_viewer]
+
+
+def build_menu() -> Menu:
+    menu = Menu()
+    for module in MODULES:
+        module.register(menu)
+    return menu
+
+
+def main() -> None:
+    menu = build_menu()
+    menu.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/ModularRoot/Arkhive/modules/image_viewer.py
+++ b/ModularRoot/Arkhive/modules/image_viewer.py
@@ -1,0 +1,15 @@
+"""Placeholder image viewer module."""
+from typing import Protocol
+
+
+class MenuProtocol(Protocol):
+    def add_option(self, label: str, callback): ...
+
+
+def register(menu: MenuProtocol) -> None:
+    """Register image viewer with the shared menu."""
+
+    def run() -> None:
+        print("Launching image viewer placeholder...")
+
+    menu.add_option("Image Viewer", run)

--- a/ModularRoot/Arkhive/modules/text_editor.py
+++ b/ModularRoot/Arkhive/modules/text_editor.py
@@ -1,0 +1,15 @@
+"""Placeholder text editor module."""
+from typing import Protocol
+
+
+class MenuProtocol(Protocol):
+    def add_option(self, label: str, callback): ...
+
+
+def register(menu: MenuProtocol) -> None:
+    """Register text editor with the shared menu."""
+
+    def run() -> None:
+        print("Launching text editor placeholder...")
+
+    menu.add_option("Text Editor", run)

--- a/ModularRoot/Arkhive/shared/menu.py
+++ b/ModularRoot/Arkhive/shared/menu.py
@@ -1,0 +1,25 @@
+"""Shared menu system used by modular apps."""
+from typing import Callable, List, Tuple
+
+
+class Menu:
+    """Simple text-based menu."""
+
+    def __init__(self) -> None:
+        self.options: List[Tuple[str, Callable[[], None]]] = []
+
+    def add_option(self, label: str, callback: Callable[[], None]) -> None:
+        """Register a new option with the menu."""
+        self.options.append((label, callback))
+
+    def show(self) -> None:
+        """Display the menu and execute the chosen option."""
+        print("Dimmi Modular Menu")
+        for index, (label, _) in enumerate(self.options, 1):
+            print(f"{index}. {label}")
+        choice = input("Select an option: ")
+        try:
+            _, callback = self.options[int(choice) - 1]
+            callback()
+        except (ValueError, IndexError):
+            print("Invalid selection.")

--- a/ModularRoot/README.md
+++ b/ModularRoot/README.md
@@ -1,0 +1,5 @@
+# ModularRoot
+
+Prototype area for experimenting with modular Python apps for Dimmi.
+
+This folder contains an `Arkhive` with a shared menu system and example modules (text editor, image viewer). These serve as templates for building additional apps that integrate through the common menu.


### PR DESCRIPTION
## Summary
- scaffold `ModularRoot` prototype to explore modular Python apps
- include shared menu system and example text editor and image viewer modules
- document architecture and notes for future expansion

## Testing
- `python -m pytest`
- `python -m py_compile ModularRoot/Arkhive/main.py ModularRoot/Arkhive/shared/menu.py ModularRoot/Arkhive/modules/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6aec6e0f8832c9e3e1c29504b039e