### PR TITLE
Add navigation shortcuts and README links

### DIFF
--- a/DimmiD/README.md
+++ b/DimmiD/README.md
@@ -26,3 +26,5 @@ The boot path: `Start.txt` loads dimmi-code and dimmi-talk, reads memory, branch
 Templates such as `Templates/PrePrompt-L1-Bootstrap.txt` and `Templates/ChoosePath-Template.txt` demonstrate preprompting and choose-your-own-adventure flows.
 
 To retrain GPT4All, feed the contents of `DimmiD/` in order: start, mind, abilities, templates, proprompts, and memory examples. The package is self-contained and mirrors the root project’s Start sequence in simplified offline form.
+
+[Back to root](../INDEX.md)

--- a/MEMORY/KEY.txt
+++ b/MEMORY/KEY.txt
@@ -32,3 +32,5 @@ location="dimmi/templates/PREPROMPTS/"
 **SceneDNA**: Metadata that connects files/images/audio to emotional, narrative, or functional continuity across modalities.
 
 (Glossary to expand with use.)
+
+[Back to START](../START/START.md)

--- a/MEMORY/README.md
+++ b/MEMORY/README.md
@@ -1,0 +1,30 @@
+# Memory Module
+
+Core glossary and memory instructions.
+
+- [Glossary of Dimmi terms](KEY.txt)
+
+[Back to root](../INDEX.md)
+
+/// === PROPROMPT:BEGIN ===
+id: PP-20250903-070410-memory-readme
+title: Maintain Memory README links
+role: Cleaner
+priority: P2
+parent: null
+scope: D
+inputs:
+  source: MEMORY/README.md
+  focus: link updates
+outputs:
+  - MEMORY/README.md
+checks:
+  - verify linked files exist
+spawn_rules: []
+status: pending
+owner: auto
+created: 2025-09-03T07:04:10Z
+updated: 2025-09-03T07:04:10Z
+notes: |
+  Add references if new memory docs appear.
+/// === PROPROMPT:END ===

--- a/MIND/Dimmi-Mind.txt
+++ b/MIND/Dimmi-Mind.txt
@@ -377,3 +377,5 @@ changelog:
         - tool governor rigor; numeric discipline; propaganda/fallacy modules; dual_doodling v1.2
       lineage_notes:
         - Builds on v4.0.0 engine and incorporates the Dual Doodling protocol. :contentReference[oaicite:5]{index=5} :contentReference[oaicite:6]{index=6}
+
+[Back to START](../START/START.md)

--- a/MIND/README.md
+++ b/MIND/README.md
@@ -1,0 +1,30 @@
+# MIND Module
+
+Central instructions for Dimmi's deep reasoning.
+
+- [Dimmi-Mind instructions](Dimmi-Mind.txt)
+
+[Back to root](../INDEX.md)
+
+/// === PROPROMPT:BEGIN ===
+id: PP-20250903-070400-mind-readme
+title: Maintain Mind module README links
+role: Cleaner
+priority: P2
+parent: null
+scope: D
+inputs:
+  source: MIND/README.md
+  focus: link updates
+outputs:
+  - MIND/README.md
+checks:
+  - verify linked files exist
+spawn_rules: []
+status: pending
+owner: auto
+created: 2025-09-03T07:04:00Z
+updated: 2025-09-03T07:04:00Z
+notes: |
+  Add new links when additional Mind files are introduced.
+/// === PROPROMPT:END ===

--- a/Mind/Mind-Predictive.txt
+++ b/Mind/Mind-Predictive.txt
@@ -744,3 +744,4 @@ These tags are used within Dimmi-Memory.txt and on the Cognitive Bus to label an
 
 END OF FILE: Mind-Predictive.txt
 ========================================
+[Back to START](../START/START.md)

--- a/Mind/README.md
+++ b/Mind/README.md
@@ -1,0 +1,30 @@
+# Mind Routes
+
+Gateway for predictive planning routines.
+
+- [Mind-Predictive instructions](Mind-Predictive.txt)
+
+[Back to root](../INDEX.md)
+
+/// === PROPROMPT:BEGIN ===
+id: PP-20250903-070405-mindroutes-readme
+title: Maintain Mind Routes README links
+role: Cleaner
+priority: P2
+parent: null
+scope: D
+inputs:
+  source: Mind/README.md
+  focus: link updates
+outputs:
+  - Mind/README.md
+checks:
+  - verify linked files exist
+spawn_rules: []
+status: pending
+owner: auto
+created: 2025-09-03T07:04:05Z
+updated: 2025-09-03T07:04:05Z
+notes: |
+  Expand link list if new Mind route files are added.
+/// === PROPROMPT:END ===


### PR DESCRIPTION
## Summary
- Add back-to-root link in DimmiD/README and append back-to-start links in key module text files for easier navigation.
- Introduce README guides for MIND, Mind, and MEMORY directories with quick links and PROPROMPT maintenance blocks.

## Testing
- `python -m py_compile DimmiD/dimmi_core.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7e80ed4d0832c9db5ccde91451a36