### PR TITLE
Add run script and docs for WebEditor

### DIFF
--- a/THINK/APPS/WebEditor/PROPROMPTS
+++ b/THINK/APPS/WebEditor/PROPROMPTS
@@ -2,3 +2,4 @@
 - Create automated tests for file operations and directory listing.
 - Add syntax highlighting for the editor.
 - Implement token expiration and logout.
+- Set up a systemd service to run the WebEditor via run_server.sh on boot.

--- a/THINK/APPS/WebEditor/README.md
+++ b/THINK/APPS/WebEditor/README.md
@@ -1,0 +1,30 @@
+# WebEditor
+
+A simple Flask-based file browser and editor. Authentication is handled via a small token system in `auth.py`.
+
+## Quick start
+
+1. Install the Python packages:
+   ```bash
+   pip install flask gunicorn
+   ```
+2. Run the server:
+   ```bash
+   ./run_server.sh
+   ```
+   This uses `gunicorn` to serve `server:app` on port 8000.
+
+## Running on itsjustlife.cloud
+
+To run this app on the cloud server:
+
+1. SSH into the machine:
+   ```bash
+   ssh <your-user>@itsjustlife.cloud
+   ```
+2. Navigate to the project folder and start the server:
+   ```bash
+   cd /path/to/dimmi/THINK/APPS/WebEditor
+   ./run_server.sh
+   ```
+   The app will listen on `http://localhost:8000`. Use a reverse proxy like Nginx if you need a public URL.

--- a/THINK/APPS/WebEditor/run_server.sh
+++ b/THINK/APPS/WebEditor/run_server.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Launch the WebEditor Flask app using gunicorn.
+# Binds to all interfaces on port 8000 so it can be accessed remotely.
+set -e
+cd "$(dirname "$0")"
+exec gunicorn --bind 0.0.0.0:8000 server:app


### PR DESCRIPTION
## Summary
- add gunicorn-based `run_server.sh` for WebEditor
- document WebEditor setup and cloud deployment in README
- note follow-up systemd task in WebEditor's PROPROMPTS

## Testing
- `python -m py_compile THINK/APPS/WebEditor/server.py THINK/APPS/WebEditor/auth.py`
- `pip install flask gunicorn`
- `THINK/APPS/WebEditor/run_server.sh & sleep 2; pgrep -fl gunicorn; pkill gunicorn`


------
https://chatgpt.com/codex/tasks/task_e_68b7f72bacd4832c8cd08bf0c22b3c61