### PR TITLE
feat: improve repo organizer dry-run flow

### DIFF
--- a/THINK/ProPrompts/repo_organizer_followup.txt
+++ b/THINK/ProPrompts/repo_organizer_followup.txt
@@ -1,0 +1,8 @@
+name: repo_organizer_followup
+begin: |
+  Extend repo_organizer.py so all Python apps share a common menu-driven GUI.
+  Register every new app in Apps/ and keep DIRECTORY.md and breadcrumbs current.
+  Add pre-commit checks that run the map command and block commits when maps are stale.
+end: |
+  Stop when the repository layout stays clean and navigation pages update themselves.
+result: markdown

--- a/THINK/SCRIPTS/repo_organizer.py
+++ b/THINK/SCRIPTS/repo_organizer.py
@@ -171,17 +171,17 @@ def cmd_stage(args) -> None:
     apps = detect_apps()
     apps_dir = REPO_ROOT / "Apps"
     if args.dry_run:
-        print("[dry-run] would create Apps registry")
-    else:
-        for lang, paths in apps.items():
-            for p in paths:
-                target = REPO_ROOT / p
-                link_dir = apps_dir / lang
-                ensure_dir(link_dir)
-                link = link_dir / Path(p).name
-                if link.exists() or link.is_symlink():
-                    continue
-                os.symlink(target, link)
+        print("[dry-run] would create Apps registry and DIRECTORY")
+        return
+    for lang, paths in apps.items():
+        for p in paths:
+            target = REPO_ROOT / p
+            link_dir = apps_dir / lang
+            ensure_dir(link_dir)
+            link = link_dir / Path(p).name
+            if link.exists() or link.is_symlink():
+                continue
+            os.symlink(target, link)
     # Apps README
     readme_lines = ["# Apps", ""]
     for lang, paths in apps.items():
@@ -243,6 +243,9 @@ def cmd_apply(args) -> None:
 
 
 def cmd_map(args) -> None:
+    if getattr(args, "dry_run", False):
+        print("[dry-run] would regenerate START and HUB maps")
+        return
     start_path = REPO_ROOT / "O" / "START.md"
     lines = ["# START", "", "- [Hub](HUB/README.md)", "- [Arkhive](Arkhive/Arkhive.md)", "- [Dimmi](Dimmi/README.md)", "- [Apps](../Apps/README.md)"]
     write_text(start_path, "\n".join(lines) + "\n")
@@ -263,6 +266,9 @@ def cmd_map(args) -> None:
 
 
 def cmd_history(args) -> None:
+    if getattr(args, "dry_run", False):
+        print("[dry-run] would record repository tree snapshot")
+        return
     when_dir = REPO_ROOT / "O" / "Dimmi" / "Memory" / "When"
     ensure_dir(when_dir)
     timestamp = _dt.datetime.now().strftime("%Y%m%d%H%M%S")
@@ -305,9 +311,11 @@ def main(argv: List[str] | None = None) -> None:
     p_apply.set_defaults(func=cmd_apply)
 
     p_map = sub.add_parser("map", help="regenerate START/HUB pages")
+    p_map.add_argument("--dry-run", action="store_true")
     p_map.set_defaults(func=cmd_map)
 
     p_hist = sub.add_parser("history", help="record repository tree snapshot")
+    p_hist.add_argument("--dry-run", action="store_true")
     p_hist.set_defaults(func=cmd_history)
 
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- add dry-run option to map and history subcommands
- ensure stage respects dry-run and doesn't write files
- add follow-up ProPrompt for expanding repository organizer tooling

## Testing
- `python3 THINK/SCRIPTS/repo_organizer.py inventory --dry-run`
- `python3 THINK/SCRIPTS/repo_organizer.py plan --dry-run`
- `python3 THINK/SCRIPTS/repo_organizer.py stage --dry-run`
- `python3 THINK/SCRIPTS/repo_organizer.py map --dry-run`
- `python3 THINK/SCRIPTS/repo_organizer.py history --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68b88275c04c832cb36d47625c6e9eca