### PR TITLE
feat: enhance Dimmi Cloud web editor

### DIFF
--- a/CLOUD/README.md
+++ b/CLOUD/README.md
@@ -1,0 +1,11 @@
+# DIMMI CLOUD
+
+Single-file PHP editor placed here for safety.
+
+## Run locally
+
+```
+php -S localhost:8000 -t .
+```
+
+Then visit [http://localhost:8000](http://localhost:8000) and log in with the credentials set at the top of `index.php` (defaults `admin`/`admin`).

--- a/CLOUD/index.php
+++ b/CLOUD/index.php
@@ -27,6 +27,18 @@ function is_text($path) {
     return in_array($ext, $whitelist);
 }
 
+function delete_recursive($path) {
+    if (is_dir($path)) {
+        foreach (scandir($path) as $name) {
+            if ($name === '.' || $name === '..') continue;
+            delete_recursive($path . '/' . $name);
+        }
+        rmdir($path);
+    } else {
+        unlink($path);
+    }
+}
+
 function handle_api() {
     global $ROOT;
     if (!isset($_GET['api'])) return;
@@ -82,12 +94,7 @@ function handle_api() {
         case 'delete':
             $abs = safe_abs($path);
             if ($abs===false) json_response(['error'=>'bad path'],400);
-            if (is_dir($abs)) {
-                if (count(scandir($abs))>2) json_response(['error'=>'dir not empty'],400);
-                rmdir($abs);
-            } else {
-                unlink($abs);
-            }
+            delete_recursive($abs);
             json_response(['ok'=>true]);
         case 'rename':
             $abs = safe_abs($path);

--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 This repository hosts personal notes and a small web interface for editing them.
 
-## WebEditor
+## DIMMI CLOUD
 
-The `ui/index.php` script provides a standalone PHP editor. It requires no
-dependencies beyond standard PHP and confines access to the repository root.
-Adjust `$USER`, `$PASS`, and `$ROOT` at the top of the file to configure login
-and the jail path.
+The `CLOUD/index.php` script provides a standalone PHP editor named **DIMMI CLOUD**.
+It requires no dependencies beyond standard PHP and confines access to the
+repository root. Adjust `$USER` and `$PASS` at the top of the file to configure
+login. The jail path is automatically set to the repository root.
+
+To run it locally:
+
+```
+php -S localhost:8000 -t CLOUD
+```
+
+Then visit `http://localhost:8000` in a browser and log in with your
+credentials.
 
 Enhancement ideas and follow-up tasks are tracked in
 `THINK/APPS/WebEditor/PROPROMPTS`.

--- a/THINK/APPS/WebEditor/PROPROMPTS
+++ b/THINK/APPS/WebEditor/PROPROMPTS
@@ -1,5 +1,5 @@
 - Add proper YAML formatting and minify support using an inline parser.
 - Embed link references directly in OPML notes instead of using sidecar files.
 - Move credentials into a separate config to support multiple users.
-- Allow recursive deletion of directories with a confirmation step.
+- Explore a trash/undo mechanism for deletions now that directories can be removed recursively.
 - Investigate porting DIMMI CLOUD to a Python-based modular GUI shared with other apps.

--- a/THINK/APPS/WebEditor/PROPROMPTS
+++ b/THINK/APPS/WebEditor/PROPROMPTS
@@ -1,3 +1,5 @@
 - Add proper YAML formatting and minify support using an inline parser.
 - Embed link references directly in OPML notes instead of using sidecar files.
 - Move credentials into a separate config to support multiple users.
+- Allow recursive deletion of directories with a confirmation step.
+- Investigate porting DIMMI CLOUD to a Python-based modular GUI shared with other apps.

--- a/THINK/APPS/WebEditor/README.md
+++ b/THINK/APPS/WebEditor/README.md
@@ -1,14 +1,16 @@
-# WebEditor
+# DIMMI CLOUD
 
-A single-file PHP WebEditor for browsing and editing files inside the repo.
+A single-file PHP editor for browsing and editing files inside the repo.
 
 ## Features
-- Session-based login (defaults admin/admin; edit credentials at top of `ui/index.php`)
+- Session-based login (defaults admin/admin; edit credentials at top of `CLOUD/index.php`)
 - Path jail that prevents escaping the repository root
-- Breadcrumb navigation with a quick-jump path input
+- Breadcrumb navigation with a quick-jump path input and a Root button
 - Rename confirmation that allows moving files by entering a new path
+- Delete buttons for files and empty folders
 - Formatting helpers for JSON and OPML (YAML support still pending)
 - Links pane that saves cross-document links in `.links.json` files
 
 ## Usage
-Place `ui/index.php` on a PHP-enabled host and set the `$ROOT` variable to your repository path. No extra dependencies are required.
+Place `CLOUD/index.php` on a PHP-enabled host. No extra dependencies are required.
+The root jail automatically points to the repository directory.

--- a/THINK/APPS/WebEditor/README.md
+++ b/THINK/APPS/WebEditor/README.md
@@ -7,7 +7,7 @@ A single-file PHP editor for browsing and editing files inside the repo.
 - Path jail that prevents escaping the repository root
 - Breadcrumb navigation with a quick-jump path input and a Root button
 - Rename confirmation that allows moving files by entering a new path
-- Delete buttons for files and empty folders
+- Delete buttons for files and folders (recursively removes folder contents)
 - Formatting helpers for JSON and OPML (YAML support still pending)
 - Links pane that saves cross-document links in `.links.json` files
 


### PR DESCRIPTION
## Summary
- rebrand interface to **DIMMI CLOUD**
- add root navigation button and delete buttons for files and folders
- expand editor area with scroll controls for quick home/end navigation
- move web editor into new `CLOUD` directory with automatic repository root detection
- document running the editor locally and note future Python GUI exploration

## Testing
- `php -l CLOUD/index.php`
- `php -S 127.0.0.1:8000 -t CLOUD &` (served login page, then process killed)


------
https://chatgpt.com/codex/tasks/task_e_68b9109dc328832c91b24b78290e3a7f