### PR TITLE
Improve WebEditor mobile support and add file management buttons

### DIFF
--- a/CLOUD/index.php
+++ b/CLOUD/index.php
@@ -128,6 +128,7 @@ if (isset($_GET['api'])) {
     if (empty($_FILES['file'])) bad('No file');
     $tmp=$_FILES['file']['tmp_name']; $name=basename($_FILES['file']['name']);
     $dst=safe_abs($path.'/'.$name); if($dst===false) bad('Bad target');
+    $dir=dirname($dst); if(!is_dir($dir)) @mkdir($dir,0775,true);
     $ok=move_uploaded_file($tmp,$dst); audit('upload',rel_of($dst),$ok); j(['ok'=>$ok,'name'=>$name]);
   }
 
@@ -155,7 +156,7 @@ if (isset($_GET['api'])) {
 
 /* ===== HTML (UI) ===== */
 if (!$authed): ?>
-<!doctype html><meta charset="utf-8"><title><?=$TITLE?> — Login</title>
+<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title><?=$TITLE?> — Login</title>
 <style>
 body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif;background:#0f0f12;color:#e5e5e5;display:grid;place-items:center;height:100dvh;margin:0}
 .card{background:#141418;border:1px solid #2e2e36;padding:24px;border-radius:16px;min-width:280px}
@@ -174,7 +175,7 @@ button{width:100%;padding:10px 12px;background:#1e1e26;border:1px solid #3a3a46;
 </form></div>
 <?php exit; endif; ?>
 
-<!doctype html><meta charset="utf-8"><title><?=$TITLE?></title>
+<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title><?=$TITLE?></title>
 <style>
 :root{--bg:#0f0f12;--panel:#121218;--line:#262631;--text:#e5e5e5}
 *{box-sizing:border-box} html,body{height:100%}
@@ -188,12 +189,17 @@ body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,-ap
 .body{padding:8px;overflow:auto}
 ul{list-style:none;margin:0;padding:0} li{padding:6px;border-radius:8px;cursor:pointer} li:hover{background:#181822}
 small{opacity:.6} .row{display:flex;gap:8px;align-items:center;justify-content:space-between}
+.actions{display:flex;gap:4px;align-items:center}
+.btn.small{padding:2px 4px;font-size:12px}
 .editorbar{padding:8px;border-bottom:1px solid var(--line);display:flex;gap:8px;align-items:center}
 .tag{background:#1e1e26;border:1px solid var(--line);padding:3px 6px;border-radius:6px;font-size:12px}
 .mono{font-family:ui-monospace,Consolas,monospace}
-textarea{width:100%;height:100%;resize:none;background:#0e0e14;color:#e5e5e5;border:0;padding:12px;font-family:ui-monospace,Consolas,monospace}
+textarea{width:100%;height:100%;flex:1;min-height:200px;resize:none;background:#0e0e14;color:#e5e5e5;border:0;padding:12px;font-family:ui-monospace,Consolas,monospace}
 footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 .crumb a{color:#aee;text-decoration:none;margin-right:6px}.crumb a:hover{text-decoration:underline}
+@media(max-width:600px){
+  .grid{grid-template-columns:1fr;grid-template-rows:200px 200px 1fr;height:auto}
+}
 </style>
 
 <div class="top">
@@ -208,7 +214,9 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 
 <div class="grid">
   <div class="panel">
-    <div class="head"><strong>FIND</strong><button class="btn" onclick="mkdirPrompt()">+ Folder</button></div>
+    <div class="head"><strong>FIND</strong><button class="btn" onclick="mkdirPrompt()">+ Folder</button>
+      <label class="btn" style="position:relative;overflow:hidden">Upload Folder<input type="file" webkitdirectory multiple style="position:absolute;inset:0;opacity:0" onchange="uploadFolder(this)"></label>
+    </div>
     <div class="body"><ul id="folderList"></ul></div>
   </div>
   <div class="panel">
@@ -219,6 +227,7 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
   </div>
   <div class="panel">
     <div class="editorbar">
+      <strong>CONTENT</strong>
       <span class="tag" id="fileName">—</span>
       <span class="tag mono" id="fileSize"></span>
       <span class="tag" id="fileWhen"></span>
@@ -251,8 +260,10 @@ async function init(){
   const info=await (await api('whereami')).json(); rootNote.textContent='root: '+(info.root||'(unset)'); openDir('');
 }
 function ent(name,rel,isDir,size,mtime){
-  const li=document.createElement('li'); li.innerHTML=`<div class="row"><div>${isDir?'📁':'📄'} ${name}</div><small>${isDir?'':fmtSize(size)}</small></div>`;
-  li.onclick=()=> isDir? openDir(rel) : openFile(rel,name,size,mtime); return li;
+  const li=document.createElement('li');
+  li.innerHTML=`<div class="row"><div>${isDir?'📁':'📄'} ${name}</div><div class="actions">${isDir?'':'<small>'+fmtSize(size)+'</small>'}<button class="btn small" onclick="renameItem(event,'${rel}')">Rename</button><button class="btn small" onclick="deleteItem(event,'${rel}')">Delete</button></div></div>`;
+  li.onclick=()=> isDir? openDir(rel) : openFile(rel,name,size,mtime);
+  return li;
 }
 async function openDir(rel){
   currentDir = rel || ''; crumb(currentDir);
@@ -300,6 +311,35 @@ async function uploadFile(inp){
   if(!inp.files.length) return; const fd=new FormData(); fd.append('file',inp.files[0]);
   const r=await (await fetch(`?api=upload&`+new URLSearchParams({path:currentDir}),{method:'POST',headers:{'X-CSRF':CSRF},body:fd})).json();
   if(!r.ok){alert(r.error||'upload failed');return;} openDir(currentDir);
+}
+
+async function uploadFolder(inp){
+  if(!inp.files.length) return;
+  for(const f of inp.files){
+    const fd=new FormData(); fd.append('file',f);
+    const relPath=f.webkitRelativePath||f.name;
+    const subdir=relPath.split('/').slice(0,-1).join('/');
+    const target=currentDir+(subdir?`/${subdir}`:'');
+    const r=await (await fetch(`?api=upload&`+new URLSearchParams({path:target}),{method:'POST',headers:{'X-CSRF':CSRF},body:fd})).json();
+    if(!r.ok){alert(r.error||'upload failed');return;}
+  }
+  openDir(currentDir);
+}
+
+async function renameItem(ev,rel){
+  ev.stopPropagation();
+  const name=prompt('Rename to:'); if(!name) return;
+  const r=await (await fetch(`?api=rename&`+new URLSearchParams({path:rel}),{method:'POST',headers:{'X-CSRF':CSRF},body:JSON.stringify({name})})).json();
+  if(!r.ok){alert(r.error||'rename failed');return;} openDir(currentDir);
+}
+
+async function deleteItem(ev,rel){
+  ev.stopPropagation();
+  if(!confirm('Delete this item?')) return;
+  const r=await (await fetch(`?api=delete&`+new URLSearchParams({path:rel}),{method:'POST',headers:{'X-CSRF':CSRF}})).json();
+  if(!r.ok){alert(r.error||'delete failed');return;}
+  if(currentFile===rel){ document.getElementById('ta').value=''; document.getElementById('ta').disabled=true; btns(false); currentFile=''; }
+  openDir(currentDir);
 }
 async function formatDoc(){
   if(!currentFile) return; const body=JSON.stringify({content:document.getElementById('ta').value});


### PR DESCRIPTION
## Summary
- make the WebEditor responsive with mobile viewport, media queries, and a bigger content area
- add rename/delete buttons for each file or folder and allow uploading entire folders
- label the content panel and ensure uploads create missing directories

## Testing
- `php -l CLOUD/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b91eb02a58832c92a698e7406d80bf