### PR TITLE
Remove default admin warning banner

### DIFF
--- a/CLOUD/ui/ui.php
+++ b/CLOUD/ui/ui.php
@@ -622,9 +622,6 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 }
 </style>
 
-<?php if($USER==='admin' && $PASS==='admin'): ?>
-<div style="background:#ff0;color:#000;padding:8px;text-align:center;">Warning: default admin credentials</div>
-<?php endif; ?>
 <div class="top">
   <div class="path" id="rootNote">root: …</div>
   <div class="crumb" id="crumb"></div>


### PR DESCRIPTION
## Summary
- remove hardcoded admin credential warning banner from the UI

## Testing
- `php -l CLOUD/ui/ui.php`
- `php -r '$USER="admin";$PASS="admin";include "CLOUD/ui/ui.php";'`


------
https://chatgpt.com/codex/tasks/task_e_68ba0e6dad84832cacf7309dd0346303