### PR TITLE
Remove alert when file open fails

### DIFF
--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -327,7 +327,7 @@ function fmtWhen(s){ try{return new Date(s*1000).toLocaleString();}catch{return 
 async function openFile(rel,name,size,mtime){
   currentFile=rel; fileName.textContent=name; fileSize.textContent=size?fmtSize(size):''; fileWhen.textContent=mtime?fmtWhen(mtime):'';
   const r=await (await api('read',{path:rel})).json(); const ta=document.getElementById('ta');
-  if(!r.ok){ alert(r.error||'Cannot open'); ta.value=''; ta.disabled=true; btns(false); return; }
+  if (!r.ok) { ta.value=''; ta.disabled=true; btns(false); return; }
   ta.value=r.content; ta.disabled=false; btns(true);
   // [PATCH] enable Tree toggle if an OPML is open
   const ext=name.toLowerCase().split('.').pop();


### PR DESCRIPTION
## Summary
- Avoid disruptive alert when opening a file fails
- Disable the editor quietly when file contents can't be loaded

## Testing
- `php -l CLOUD/cloud.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba43471448832caa50f3fd16f38ecf