### PR TITLE
Add modal-based new file dialog with extension shortcuts

### DIFF
--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -204,7 +204,7 @@ button{width:100%;padding:10px 12px;background:#1e1e26;border:1px solid #3a3a46;
 
 <!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title><?=$TITLE?></title>
 <style>
-:root{--bg:#0f0f12;--panel:#121218;--line:#262631;--text:#e5e5e5}
+:root{--bg:#0f0f12;--panel:#121218;--line:#262631;--text:#e5e5e5;--accent:#7cc9ff}
 *{box-sizing:border-box} html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif}
 .top{display:flex;gap:12px;align-items:center;padding:10px;border-bottom:1px solid var(--line)}
@@ -224,6 +224,9 @@ small{opacity:.6} .row{display:flex;gap:8px;align-items:center;justify-content:s
 textarea{width:100%;height:100%;flex:1;min-height:200px;resize:none;background:#0e0e14;color:#e5e5e5;border:0;padding:12px;font-family:ui-monospace,Consolas,monospace}
 footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 .crumb a{color:#aee;text-decoration:none;margin-right:6px}.crumb a:hover{text-decoration:underline}
+#newFileModal{position:fixed; inset:0; display:none; align-items:center; justify-content:center; background:rgba(0,0,0,.4); z-index:50}
+#newFileModal .box{background:var(--panel); border:1px solid var(--line); border-radius:14px; padding:20px; display:flex; flex-direction:column; gap:10px; width:260px}
+#newFileModal .ext.selected{outline:2px solid var(--accent)}
 @media(max-width:600px){
   .grid{grid-template-columns:1fr;grid-template-rows:200px 200px 1fr;height:auto}
 }
@@ -279,12 +282,29 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
     </div>
   </div>
 </div>
+<div id="newFileModal">
+  <div class="box">
+    <input id="newFileName" class="input" placeholder="new file name">
+    <div class="row" id="extBtns" style="gap:6px">
+      <button class="btn small ext" data-ext=".txt">.txt</button>
+      <button class="btn small ext" data-ext=".html">.html</button>
+      <button class="btn small ext" data-ext=".md">.md</button>
+      <button class="btn small ext" data-ext=".opml">.opml</button>
+    </div>
+    <div class="row" style="justify-content:flex-end; gap:6px">
+      <button class="btn small" id="newFileCreateBtn">Create</button>
+      <button class="btn small" id="newFileCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
 <footer><?=$TITLE?></footer>
 
 <script>
 const CSRF = '<?=htmlspecialchars($_SESSION['csrf'] ?? '')?>';
 const api=(act,params)=>fetch(`?api=${act}&`+new URLSearchParams(params||{}));
 let currentDir='', currentFile='';
+const newExts=['.txt','.html','.md','.opml'];
+let newExtIndex=0;
 const listBtn=document.getElementById('structListBtn');
 const treeBtn=document.getElementById('structTreeBtn');
 const treeWrap=document.getElementById('opmlTreeWrap');
@@ -351,10 +371,39 @@ async function mkdirPrompt(){
   const r=await (await fetch(`?api=mkdir&`+new URLSearchParams({path:currentDir}),{method:'POST',headers:{'X-CSRF':CSRF},body:JSON.stringify({name})})).json();
   if(!r.ok){alert(r.error||'mkdir failed');return;} openDir(currentDir);
 }
-async function newFilePrompt(){
-  const name=prompt('New file name:'); if(!name) return;
+function newFilePrompt(){
+  const m=document.getElementById('newFileModal');
+  const input=document.getElementById('newFileName');
+  m.style.display='flex';
+  newExtIndex=0;
+  updateExtBtns();
+  input.value='';
+  input.focus();
+}
+
+function updateExtBtns(){
+  document.querySelectorAll('#extBtns .ext').forEach((b,i)=>{
+    b.classList.toggle('selected', i===newExtIndex);
+  });
+}
+document.querySelectorAll('#extBtns .ext').forEach((btn,i)=>{
+  btn.addEventListener('click',()=>{ newExtIndex=i; updateExtBtns(); document.getElementById('newFileName').focus(); });
+});
+document.getElementById('newFileName').addEventListener('keydown',(e)=>{
+  if(e.key==='Tab'){ e.preventDefault(); newExtIndex=(newExtIndex+1)%newExts.length; updateExtBtns(); }
+  if(e.key==='Enter'){ e.preventDefault(); createNewFile(); }
+});
+document.getElementById('newFileCreateBtn').addEventListener('click', createNewFile);
+document.getElementById('newFileCancelBtn').addEventListener('click', ()=>{ document.getElementById('newFileModal').style.display='none'; });
+
+async function createNewFile(){
+  let name=document.getElementById('newFileName').value.trim();
+  if(!name) return;
+  if(!name.includes('.')) name+=newExts[newExtIndex];
   const r=await (await fetch(`?api=newfile&`+new URLSearchParams({path:currentDir}),{method:'POST',headers:{'X-CSRF':CSRF},body:JSON.stringify({name})})).json();
-  if(!r.ok){alert(r.error||'newfile failed');return;} openDir(currentDir);
+  if(!r.ok){ alert(r.error||'newfile failed'); return; }
+  document.getElementById('newFileModal').style.display='none';
+  openDir(currentDir);
 }
 async function uploadFile(inp){
   if(!inp.files.length) return; const fd=new FormData(); fd.append('file',inp.files[0]);

--- a/CLOUD/node/index.html
+++ b/CLOUD/node/index.html
@@ -1,6 +1,6 @@
 <!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>{{TITLE}}</title>
 <style>
-:root{--bg:#0f0f12;--panel:#121218;--line:#262631;--text:#e5e5e5}
+:root{--bg:#0f0f12;--panel:#121218;--line:#262631;--text:#e5e5e5;--accent:#7cc9ff}
 *{box-sizing:border-box} html,body{height:100%}
 body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Helvetica,Arial,sans-serif}
 .top{display:flex;gap:12px;align-items:center;padding:10px;border-bottom:1px solid var(--line)}
@@ -20,6 +20,9 @@ small{opacity:.6} .row{display:flex;gap:8px;align-items:center;justify-content:s
 textarea{width:100%;height:100%;flex:1;min-height:200px;resize:none;background:#0e0e14;color:#e5e5e5;border:0;padding:12px;font-family:ui-monospace,Consolas,monospace}
 footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 .crumb a{color:#aee;text-decoration:none;margin-right:6px}.crumb a:hover{text-decoration:underline}
+#newFileModal{position:fixed; inset:0; display:none; align-items:center; justify-content:center; background:rgba(0,0,0,.4); z-index:50}
+#newFileModal .box{background:var(--panel); border:1px solid var(--line); border-radius:14px; padding:20px; display:flex; flex-direction:column; gap:10px; width:260px}
+#newFileModal .ext.selected{outline:2px solid var(--accent)}
 @media(max-width:600px){
   .grid{grid-template-columns:1fr;grid-template-rows:200px 200px 1fr;height:auto}
 }
@@ -72,12 +75,29 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
     </div>
   </div>
 </div>
+<div id="newFileModal">
+  <div class="box">
+    <input id="newFileName" class="input" placeholder="new file name">
+    <div class="row" id="extBtns" style="gap:6px">
+      <button class="btn small ext" data-ext=".txt">.txt</button>
+      <button class="btn small ext" data-ext=".html">.html</button>
+      <button class="btn small ext" data-ext=".md">.md</button>
+      <button class="btn small ext" data-ext=".opml">.opml</button>
+    </div>
+    <div class="row" style="justify-content:flex-end; gap:6px">
+      <button class="btn small" id="newFileCreateBtn">Create</button>
+      <button class="btn small" id="newFileCancelBtn">Cancel</button>
+    </div>
+  </div>
+</div>
 <footer>{{TITLE}}</footer>
 
 <script>
 const CSRF = '{{CSRF}}';
 const api=(act,params)=>fetch('api/'+act+'?'+new URLSearchParams(params||{}));
 let currentDir='', currentFile='';
+const newExts=['.txt','.html','.md','.opml'];
+let newExtIndex=0;
 const listBtn=document.getElementById('structListBtn');
 const treeBtn=document.getElementById('structTreeBtn');
 const treeWrap=document.getElementById('opmlTreeWrap');
@@ -143,10 +163,39 @@ async function mkdirPrompt(){
   const r=await (await fetch('api/mkdir?'+new URLSearchParams({path:currentDir}),{method:'POST',headers:{'X-CSRF':CSRF},body:JSON.stringify({name})})).json();
   if(!r.ok){alert(r.error||'mkdir failed');return;} openDir(currentDir);
 }
-async function newFilePrompt(){
-  const name=prompt('New file name:'); if(!name) return;
+function newFilePrompt(){
+  const m=document.getElementById('newFileModal');
+  const input=document.getElementById('newFileName');
+  m.style.display='flex';
+  newExtIndex=0;
+  updateExtBtns();
+  input.value='';
+  input.focus();
+}
+
+function updateExtBtns(){
+  document.querySelectorAll('#extBtns .ext').forEach((b,i)=>{
+    b.classList.toggle('selected', i===newExtIndex);
+  });
+}
+document.querySelectorAll('#extBtns .ext').forEach((btn,i)=>{
+  btn.addEventListener('click',()=>{ newExtIndex=i; updateExtBtns(); document.getElementById('newFileName').focus(); });
+});
+document.getElementById('newFileName').addEventListener('keydown',(e)=>{
+  if(e.key==='Tab'){ e.preventDefault(); newExtIndex=(newExtIndex+1)%newExts.length; updateExtBtns(); }
+  if(e.key==='Enter'){ e.preventDefault(); createNewFile(); }
+});
+document.getElementById('newFileCreateBtn').addEventListener('click', createNewFile);
+document.getElementById('newFileCancelBtn').addEventListener('click', ()=>{ document.getElementById('newFileModal').style.display='none'; });
+
+async function createNewFile(){
+  let name=document.getElementById('newFileName').value.trim();
+  if(!name) return;
+  if(!name.includes('.')) name+=newExts[newExtIndex];
   const r=await (await fetch('api/newfile?'+new URLSearchParams({path:currentDir}),{method:'POST',headers:{'X-CSRF':CSRF},body:JSON.stringify({name})})).json();
-  if(!r.ok){alert(r.error||'newfile failed');return;} openDir(currentDir);
+  if(!r.ok){ alert(r.error||'newfile failed'); return; }
+  document.getElementById('newFileModal').style.display='none';
+  openDir(currentDir);
 }
 async function uploadFile(inp){
   if(!inp.files.length) return; const fd=new FormData(); fd.append('file',inp.files[0]);


### PR DESCRIPTION
## Summary
- Replace simple prompt with a modal for creating new files
- Offer quick extension buttons and keyboard navigation in PHP and Node UIs
- Automatically append chosen extension if user omits one

## Testing
- `php -l CLOUD/cloud.php`
- `php -l CLOUD/ui/ui.php`
- `cd CLOUD/node && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba44bae6c4832c91a98a811139c308