### PR TITLE
Rename Tree view to ARK and display OPML notes

### DIFF
--- a/CLOUD/node/index.html
+++ b/CLOUD/node/index.html
@@ -52,7 +52,7 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
       <!-- [PATCH] List / Tree toggle -->
       <span style="margin-left:auto; display:flex; gap:6px">
         <button class="btn small" id="structListBtn" type="button">List</button>
-        <button class="btn small" id="structTreeBtn" type="button" title="Show OPML tree" disabled>Tree</button>
+        <button class="btn small" id="structTreeBtn" type="button" title="Show OPML ARK" disabled>ARK</button>
       </span>
     </div>
     <div class="body" style="position:relative">
@@ -252,9 +252,24 @@ function renderTree(nodes){
       const has=n.children && n.children.length;
       const caret=document.createElement('span'); caret.textContent=has?'▸':'•'; caret.style.cursor=has?'pointer':'default';
       const title=document.createElement('span'); title.textContent=n.t;
+
+      if(n.note){
+        title.style.cursor='pointer';
+        title.onclick=e=>{
+          e.stopPropagation();
+          const ta=document.getElementById('ta');
+          ta.value=n.note; ta.disabled=false; btns(false);
+          fileName.textContent=n.t; fileSize.textContent=''; fileWhen.textContent='';
+        };
+      }
+
       row.appendChild(caret); row.appendChild(title); li.appendChild(row);
-      if(has){ const child=ul(n.children); child.style.display='none'; li.appendChild(child);
-        row.onclick=()=>{ child.style.display=child.style.display==='none'?'block':'none'; caret.textContent=child.style.display==='none'?'▸':'▾'; };
+
+      if(has){
+        const child=ul(n.children); child.style.display='none'; li.appendChild(child);
+        const toggle=()=>{ child.style.display=child.style.display==='none'?'block':'none'; caret.textContent=child.style.display==='none'?'▸':'▾'; };
+        caret.onclick=toggle;
+        if(!n.note) row.onclick=toggle;
       }
       u.appendChild(li);
     }

--- a/CLOUD/node/server.js
+++ b/CLOUD/node/server.js
@@ -178,7 +178,11 @@ app.get('/api/opml_tree', async (req,res)=>{
     const parsed = await xml2js.parseStringPromise(xml);
     const outlines = parsed.opml && parsed.opml.body && parsed.opml.body[0] && parsed.opml.body[0].outline || [];
     function walk(nodes){
-      return nodes.map(n=>({t: n.$?.text || '', children: n.outline?walk(n.outline):[]}));
+      return nodes.map(n=>({
+        t: n.$?.text || '',
+        note: n.$?._note,
+        children: n.outline?walk(n.outline):[]
+      }));
     }
     const tree = walk(outlines);
     res.json({ok:true, tree});

--- a/CLOUD/ui/ui.php
+++ b/CLOUD/ui/ui.php
@@ -271,7 +271,9 @@ if (isset($_GET['api'])) {
         $t = $c->getAttribute('title') ?: $c->getAttribute('text') ?: '•';
         $id = ($prefix==='') ? strval($i) : ($prefix.'/'.$i);
         $childs = $c->hasChildNodes() ? $walk($c,$id) : [];
-        $out[] = ['id'=>$id,'t'=>$t,'children'=>$childs];
+        $item = ['id'=>$id,'t'=>$t,'children'=>$childs];
+        if($c->hasAttribute('_note')) $item['note']=$c->getAttribute('_note');
+        $out[] = $item;
         $i++;
       } return $out;
     };
@@ -661,7 +663,7 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
       <!-- [NODE PATCH] List / Tree toggle -->
       <span style="margin-left:auto; display:flex; gap:6px">
         <button class="btn small" id="structListBtn" type="button">List</button>
-        <button class="btn small" id="structTreeBtn" type="button" title="Show OPML tree" disabled>Tree</button>
+        <button class="btn small" id="structTreeBtn" type="button" title="Show OPML ARK" disabled>ARK</button>
       </span>
     </div>
     <div class="body" style="position:relative">
@@ -1107,7 +1109,7 @@ function renderTree(nodes){
       row.dataset.id = n.id;
       row.onclick = (e)=>{
         if(has && e.target===caret){ child.style.display = child.style.display==='none' ? 'block':'none'; caret.textContent = child.style.display==='none' ? '▸':'▾'; }
-        selectNode(n.id, n.t);
+        selectNode(n.id, n.t, n.note);
       };
       li.appendChild(row);
       if(has){ const child=mk(n.children,n.id); child.style.display='none'; li.appendChild(child); }
@@ -1124,10 +1126,15 @@ async function loadTree(){
   renderTree(data.tree||[]);
 }
 
-async function selectNode(id, title){
+async function selectNode(id, title, note){
   selectedId = id;
   nodeEditor.style.display='block';
   nodeTitle.value = title || '';
+  if(note){
+    const ta=document.getElementById('ta');
+    ta.value=note; ta.disabled=false; btns(false);
+    fileName.textContent=title||''; fileSize.textContent=''; fileWhen.textContent='';
+  }
   await refreshLinks();
 }
 


### PR DESCRIPTION
## Summary
- Rename "Tree" view controls to "ARK" across the interface
- Parse `_note` fields from OPML and surface them in the tree view
- Show a node's note in the Content pane when its title is clicked

## Testing
- `php -l CLOUD/cloud.php`
- `php -l CLOUD/ui.php`
- `php -l CLOUD/ui/ui.php`
- `node --check CLOUD/node/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba527e9820832caa2ab0cb59793aad