### PR TITLE
refactor: expand OPML tree pane

### DIFF
--- a/CLOUD/ui/ui.php
+++ b/CLOUD/ui/ui.php
@@ -669,7 +669,7 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
     <div class="body" style="position:relative">
       <div class="pullHint">↓ Pull to refresh</div>
       <ul id="fileList"></ul>
-      <div id="opmlTreeWrap" style="display:none; position:absolute; inset:8px; overflow:auto"></div>
+      <div id="opmlTreeWrap" style="display:none; height:100%; overflow:auto"></div>
       <div id="treeTools" class="row" style="display:none; gap:6px; margin-top:6px">
         <button class="btn small" id="addChildBtn">+ Child</button>
         <button class="btn small" id="addSiblingBtn">+ Sibling</button>


### PR DESCRIPTION
## Summary
- make OPML tree wrapper fill entire panel

## Testing
- `php -l CLOUD/ui/ui.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba64e286f4832cabb254b85a30a9ea