### PR TITLE
Enable JSON auto-save and inline preview editing

### DIFF
--- a/CLOUD/node/server.js
+++ b/CLOUD/node/server.js
@@ -139,11 +139,19 @@ app.post('/api/newfile', async (req,res)=>{
   try{
     let content='';
     if(name.toLowerCase().endsWith('.json')){
+      const now=new Date().toISOString();
       content=JSON.stringify({
         schemaVersion:'1.0.0',
         id:crypto.randomUUID(),
         metadata:{title:'New File Title'},
-        root:[]
+        root:[{
+          id:crypto.randomUUID(),
+          type:'note',
+          content:'This is your first item. Edit its content here.',
+          created:now,
+          modified:now,
+          metadata:{title:'Root Item'}
+        }]
       }, null, 2);
     }
     await fsp.writeFile(abs,content);


### PR DESCRIPTION
## Summary
- Fill new `.json` files with a starter document so they open correctly
- Add a `save_json_structure` endpoint and a `saveCurrentJsonStructure()` helper for auto-saving
- Let users click titles or notes in Preview to edit them inline, with instant saves

## Testing
- `php -l CLOUD/cloud.php`
- `npm test` (in `CLOUD/node`)


------
https://chatgpt.com/codex/tasks/task_e_68bd0953e344832c95736e6cf92f0427