### PR TITLE
Add JSON structure preview support

### DIFF
--- a/CLOUD/examples/basic-note.json
+++ b/CLOUD/examples/basic-note.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "basic-0001",
+  "metadata": { "title": "Basic Note" },
+  "root": [
+    {
+      "id": "basic-root",
+      "type": "note",
+      "content": "Hello from basic example.",
+      "metadata": { "title": "Hello" },
+      "children": []
+    }
+  ]
+}

--- a/CLOUD/examples/links.json
+++ b/CLOUD/examples/links.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "links-0001",
+  "metadata": { "title": "Linked Notes" },
+  "root": [
+    {
+      "id": "node-a",
+      "type": "note",
+      "content": "See node B",
+      "metadata": { "title": "Node A" },
+      "links": [ { "title": "Go to B", "target": "node-b" } ],
+      "children": []
+    },
+    {
+      "id": "node-b",
+      "type": "note",
+      "content": "This is node B.",
+      "metadata": { "title": "Node B" },
+      "children": []
+    }
+  ]
+}

--- a/CLOUD/examples/nested-notes.json
+++ b/CLOUD/examples/nested-notes.json
@@ -1,0 +1,29 @@
+{
+  "schemaVersion": "1.0.0",
+  "id": "nested-0001",
+  "metadata": { "title": "Nested Notes" },
+  "root": [
+    {
+      "id": "parent",
+      "type": "note",
+      "content": "Parent note",
+      "metadata": { "title": "Parent" },
+      "children": [
+        {
+          "id": "child1",
+          "type": "note",
+          "content": "First child",
+          "metadata": { "title": "Child One" },
+          "children": []
+        },
+        {
+          "id": "child2",
+          "type": "note",
+          "content": "Second child",
+          "metadata": { "title": "Child Two" },
+          "children": []
+        }
+      ]
+    }
+  ]
+}

--- a/CLOUD/node/index.html
+++ b/CLOUD/node/index.html
@@ -103,7 +103,8 @@ footer{position:fixed;right:10px;bottom:8px;opacity:.5}
 const CSRF = '{{CSRF}}';
 const api=(act,params)=>fetch('api/'+act+'?'+new URLSearchParams(params||{}));
 let currentDir='', currentFile='';
-let opmlDoc=null, editMode=false;
+let opmlDoc=null, jsonDoc=null, editMode=false;
+let currentMode='text';
 const newExts=['.json','.txt','.html','.md','.opml'];
 let newExtIndex=0;
 const listBtn=document.getElementById('structListBtn');
@@ -141,10 +142,15 @@ function showPreviewView(){
   codeTab.classList.remove('selected');
   ta.style.display='none';
   opmlPreview.style.display='block';
-  if(ta.value && !editBtn.disabled){
-    try{ opmlDoc=new DOMParser().parseFromString(ta.value,'application/xml'); }catch{}
+  if(currentMode==='opml'){
+    if(ta.value && !editBtn.disabled){
+      try{ opmlDoc=new DOMParser().parseFromString(ta.value,'application/xml'); }catch{}
+    }
+    renderOpmlPreview();
+  }else if(currentMode==='json'){
+    try{ jsonDoc=ta.value?JSON.parse(ta.value):[]; renderJsonPreview(jsonDoc); }
+    catch{ opmlPreview.textContent='JSON parse error.'; }
   }
-  renderOpmlPreview();
 }
 function escapeHtml(str){return str.replace(/[&<>]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[c]));}
 function mdLinks(str){return str.replace(/\[([^\]]+)\]\(([^)]+)\)/g,'<a href="$2">$1</a>');}
@@ -245,6 +251,28 @@ function serializeAndSave(){
   renderOpmlPreview();
 }
 
+function renderJsonPreview(doc){
+  const getRoot=(d)=>Array.isArray(d)?d:(Array.isArray(d.root)?d.root:(Array.isArray(d.items)?d.items:[]));
+  const getTitle=(n)=>n?.title||n?.metadata?.title||n?.content||n?.note||'';
+  const root=getRoot(doc);
+  opmlPreview.innerHTML='';
+  const walk=(node,level)=>{
+    const wrap=document.createElement('div');
+    const heading=document.createElement(level===0?'h2':'h3');
+    heading.textContent=getTitle(node);
+    wrap.appendChild(heading);
+    const note=node?.note||(node?.content&& (node.title||node.metadata?.title)?node.content:'');
+    if(note){
+      const div=document.createElement('div');
+      div.innerHTML=mdLinks(escapeHtml(note));
+      wrap.appendChild(div);
+    }
+    if(Array.isArray(node?.children)) node.children.forEach(c=>wrap.appendChild(walk(c,level+1)));
+    return wrap;
+  };
+  root.forEach(n=>opmlPreview.appendChild(walk(n,0)));
+}
+
 function toggleEdit(){
   if(!opmlDoc) return;
   editMode=!editMode;
@@ -288,7 +316,9 @@ async function openFile(rel,name,size,mtime){
   if(!r.ok){ alert(r.error||'Cannot open'); ta.value=''; ta.disabled=true; btns(false); contentTabs.style.display='none'; opmlPreview.style.display='none'; return; }
   ta.value=r.content; ta.disabled=false; btns(true);
   const ext=name.toLowerCase().split('.').pop();
+  const isJson=ext==='json';
   const isOpml=['opml','xml'].includes(ext);
+  currentMode=isJson?'json':(isOpml?'opml':'text');
   document.getElementById('structTreeBtn').disabled = !isOpml;
   hideTree();
   if(isOpml){
@@ -302,13 +332,21 @@ async function openFile(rel,name,size,mtime){
       editBtn.textContent='Edit';
       renderOpmlPreview();
     }catch{ opmlPreview.textContent='OPML parse error.'; }
+  }else if(isJson){
+    contentTabs.style.display='flex';
+    showCodeView();
+    try{ jsonDoc=JSON.parse(r.content); renderJsonPreview(jsonDoc); }
+    catch{ jsonDoc=null; opmlPreview.textContent='JSON parse error.'; }
+    editMode=false;
+    editBtn.disabled=true;
   }else{
     contentTabs.style.display='none';
     opmlPreview.style.display='none';
     ta.style.display='';
-    opmlDoc=null;
+    opmlDoc=null; jsonDoc=null;
     editMode=false;
     editBtn.disabled=true;
+    currentMode='text';
   }
 }
 function btns(on){ saveBtn.disabled=!on; delBtn.disabled=!on; }

--- a/CLOUD/node/server.js
+++ b/CLOUD/node/server.js
@@ -190,6 +190,26 @@ app.post('/api/upload', upload.single('file'), (req,res)=>{
   res.json({ok:true});
 });
 
+app.get('/api/json_tree', async (req,res)=>{
+  const abs = safeAbs(req.query.file || '');
+  if(!abs || !fs.existsSync(abs)) return bad(res,400,'Not found');
+  try{
+    const txt = await fsp.readFile(abs,'utf8');
+    const doc = JSON.parse(txt);
+    const getRoot = (d)=>{
+      if(Array.isArray(d)) return d;
+      if(d && Array.isArray(d.root)) return d.root;
+      if(d && Array.isArray(d.items)) return d.items;
+      return [];
+    };
+    const getTitle = (n)=>{
+      if(!n || typeof n!== 'object') return '';
+      return n.title || (n.metadata && n.metadata.title) || n.content || n.note || '';
+    };
+    res.json({ok:true, root:getRoot(doc), title:getTitle(doc)});
+  }catch(e){ bad(res,400,'JSON parse error'); }
+});
+
 app.get('/api/opml_tree', async (req,res)=>{
   const abs = safeAbs(req.query.file || '');
   if(!abs || !fs.existsSync(abs)) return bad(res,400,'Not found');


### PR DESCRIPTION
## Summary
- add `/api/json_tree` endpoint to parse JSON structure files
- show JSON structures in preview with new renderer
- include sample JSON structures for testing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c08c503498832cbe572fce13dc377c