### PR TITLE
Add attach wizard for DOOR teleport links

### DIFF
--- a/CLOUD/assets/css/door.css
+++ b/CLOUD/assets/css/door.css
@@ -65,6 +65,10 @@ header a:hover {
   width: 100%;
 }
 
+.door-tile-wrap {
+  position: relative;
+}
+
 .door-tile {
   aspect-ratio: 1 / 1;
   background: linear-gradient(135deg, #334155, #1e293b);
@@ -89,6 +93,30 @@ header a:hover {
   border-color: #38bdf8;
   box-shadow: 0 12px 20px rgba(56, 189, 248, 0.35);
   outline: none;
+}
+
+.door-tile-action {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  border: none;
+  border-radius: 999px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: rgba(56, 189, 248, 0.25);
+  color: #38bdf8;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.door-tile-action:hover,
+.door-tile-action:focus {
+  background: rgba(56, 189, 248, 0.4);
+  outline: none;
+  transform: translateY(-1px);
 }
 
 .door-tile.door-add {
@@ -329,6 +357,44 @@ header a:hover {
   color: #f87171;
 }
 
+.door-links-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.door-links-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.door-links-title {
+  margin: 0;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.door-link-attach {
+  border: none;
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.75rem;
+  background: rgba(56, 189, 248, 0.2);
+  color: #38bdf8;
+  font-weight: 600;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.door-link-attach:hover,
+.door-link-attach:focus {
+  background: rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
 .door-links {
   list-style: none;
   margin: 0;
@@ -348,15 +414,48 @@ header a:hover {
   border: 1px solid rgba(148, 163, 184, 0.2);
 }
 
+.door-link-meta {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.door-link-meta span {
+  line-height: 1.2;
+}
+
+.door-link-actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.door-link-edit,
 .door-link-remove {
-  background: rgba(248, 113, 113, 0.2);
-  color: #f87171;
   border: none;
   padding: 0.4rem 0.75rem;
   border-radius: 0.75rem;
   cursor: pointer;
   font-weight: 600;
   touch-action: manipulation;
+}
+
+.door-link-edit {
+  background: rgba(56, 189, 248, 0.18);
+  color: #38bdf8;
+}
+
+.door-link-edit:hover,
+.door-link-edit:focus {
+  background: rgba(56, 189, 248, 0.3);
+  outline: none;
+}
+
+.door-link-remove {
+  background: rgba(248, 113, 113, 0.2);
+  color: #f87171;
+  border: none;
 }
 
 .door-link-remove:hover {
@@ -366,31 +465,6 @@ header a:hover {
 .door-link-remove:focus {
   outline: 2px solid rgba(248, 113, 113, 0.4);
   outline-offset: 2px;
-}
-
-.door-link-form {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.door-link-form input {
-  flex: 1 1 140px;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
-}
-
-.door-link-form button {
-  padding: 0.6rem 1rem;
-  border-radius: 0.75rem;
-  border: none;
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
-  font-weight: 600;
-  cursor: pointer;
 }
 
 .door-layout {
@@ -417,4 +491,321 @@ header a:hover {
     position: sticky;
     top: 1rem;
   }
+}
+
+.door-attach-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(6px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 1.5rem;
+}
+
+.door-attach-overlay.active {
+  display: flex;
+}
+
+.door-attach-dialog {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.6);
+}
+
+.door-attach-body {
+  padding: 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-attach-body h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.door-attach-types {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.5rem;
+}
+
+.door-attach-type {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  cursor: pointer;
+  transition: border 0.2s, background 0.2s;
+}
+
+.door-attach-type strong {
+  display: block;
+  font-size: 0.95rem;
+}
+
+.door-attach-type span {
+  display: block;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin-top: 0.25rem;
+}
+
+.door-attach-type.active {
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.2);
+}
+
+.door-attach-type:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.8);
+}
+
+.door-attach-field label {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 0.35rem;
+}
+
+.door-attach-field input,
+.door-attach-field textarea {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.8);
+  color: #f8fafc;
+}
+
+.door-attach-pane {
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.door-attach-pane.active {
+  display: flex;
+}
+
+.door-attach-path {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.door-attach-path input {
+  flex: 1;
+}
+
+.door-attach-path button {
+  padding: 0.6rem 1rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: rgba(56, 189, 248, 0.2);
+  color: #38bdf8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.door-attach-path button:hover,
+.door-attach-path button:focus {
+  background: rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
+.door-attach-hint {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.door-attach-relations {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.door-attach-relations-list {
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.door-attach-relations-list button {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  text-align: left;
+  cursor: pointer;
+}
+
+.door-attach-relations-list button.active {
+  border-color: rgba(56, 189, 248, 0.6);
+  background: rgba(56, 189, 248, 0.2);
+  color: #38bdf8;
+}
+
+.door-attach-relations-empty {
+  font-size: 0.75rem;
+  color: #94a3b8;
+}
+
+.door-attach-structure-preview {
+  max-height: 160px;
+  overflow: auto;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.65);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.75rem;
+  color: #cbd5f5;
+  white-space: pre-wrap;
+}
+
+.door-attach-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem 1.5rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.door-attach-actions button {
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.door-attach-cancel {
+  background: rgba(148, 163, 184, 0.25);
+  color: #e2e8f0;
+}
+
+.door-attach-submit {
+  background: rgba(56, 189, 248, 0.35);
+  color: #0f172a;
+}
+
+.door-attach-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.door-attach-browser {
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0.75rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.door-attach-browser.active {
+  display: flex;
+}
+
+.door-attach-browser-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.door-attach-browser-path {
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.door-attach-browser-controls {
+  display: inline-flex;
+  gap: 0.4rem;
+}
+
+.door-attach-browser-controls button {
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.4rem 0.75rem;
+  background: rgba(56, 189, 248, 0.2);
+  color: #38bdf8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.door-attach-browser-controls button:hover,
+.door-attach-browser-controls button:focus {
+  background: rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
+.door-attach-browser-choose {
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.35rem 0.7rem;
+  background: rgba(56, 189, 248, 0.2);
+  color: #38bdf8;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.door-attach-browser-choose:hover,
+.door-attach-browser-choose:focus {
+  background: rgba(56, 189, 248, 0.35);
+  outline: none;
+}
+
+.door-attach-browser-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.door-attach-browser-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+}
+
+.door-attach-browser-list button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.door-attach-browser-empty {
+  font-size: 0.75rem;
+  color: #94a3b8;
 }

--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -630,14 +630,12 @@ function door_render_shell($title){
           <label>Room Note
             <textarea id="door-room-note" placeholder="Describe this room..."></textarea>
           </label>
-          <div>
-            <h2 style="margin:0 0 0.5rem;font-size:0.9rem;text-transform:uppercase;letter-spacing:0.08em;color:#94a3b8;">Teleport Links</h2>
+          <div class="door-links-block">
+            <div class="door-links-header">
+              <h2 class="door-links-title">Teleport Links</h2>
+              <button type="button" class="door-link-attach" id="door-attach">Attach…</button>
+            </div>
             <ul class="door-links" id="door-links-list"></ul>
-            <form id="door-link-form" class="door-link-form">
-              <input id="door-link-target" placeholder="Target room ID">
-              <input id="door-link-label" placeholder="Label (optional)">
-              <button type="submit">Add link</button>
-            </form>
           </div>
           <div class="door-editor-actions">
             <button type="button" class="door-save" id="door-save">Save changes</button>


### PR DESCRIPTION
## Summary
- replace the teleport link inputs in the DOOR editor with an Attach action
- implement a modal wizard that supports file, folder, URL, structure, and relation targets, including previews and FIND browsing
- refresh teleport list interactions with edit/remove controls and smarter link following

## Testing
- node --check CLOUD/assets/js/cloud-door.js
- php -l CLOUD/cloud.php

------
https://chatgpt.com/codex/tasks/task_e_68daf708db40832caed58f238372c707