### PR TITLE
Add Wikipedia top-level categories overlay for Door

### DIFF
--- a/ARKHIVE/What/README.md
+++ b/ARKHIVE/What/README.md
@@ -1,1 +1,4 @@
-Concrete objects, abstract concepts, technologies, and knowledge domains
+Concrete objects, abstract concepts, technologies, and knowledge domains.
+
+## Wikipedia alignment overlay
+Use [Wikipedia Topics](Wikipedia_Topics/README.md) when you want to mirror the high-level navigation from Wikipedia’s contents page. It gives Door users a familiar starting point while keeping everything inside the existing `WHAT` security boundary.

--- a/ARKHIVE/What/Wikipedia_Topics/Culture_and_the_Arts/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Culture_and_the_Arts/README.md
@@ -1,0 +1,8 @@
+# Culture and the Arts
+
+Creative expression, aesthetic movements, literature, music, visual arts, performing arts, design, and cultural heritage. Capture outlines of artistic traditions, notable works, or curation projects here.
+
+**Cross-links to consider:**
+- Link creators and organisations through `WHO` nodes (artists, studios, collectives).
+- Tie venues and cultural regions to `WHERE`.
+- Reference historical periods in `WHEN` to show when movements emerged.

--- a/ARKHIVE/What/Wikipedia_Topics/General_Reference/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/General_Reference/README.md
@@ -1,0 +1,8 @@
+# General Reference
+
+High-level reference works and orientation tools—encyclopedias, dictionaries, atlases, timelines, bibliographies, glossaries, and general knowledge guides. Use this space to park navigation aids or overviews that do not belong to any single discipline.
+
+**Cross-links to add when you flesh this out:**
+- Connect to `WHERE` entries for atlases, maps, and gazetteers.
+- Link to `WHEN` timelines for chronological reference collections.
+- Reference `HOW` processes for research and study techniques tied to these sources.

--- a/ARKHIVE/What/Wikipedia_Topics/Geography_and_Places/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Geography_and_Places/README.md
@@ -1,0 +1,8 @@
+# Geography and Places
+
+Physical and human geography, regions, countries, cities, landmarks, biomes, and spatial frameworks. Use this directory to sketch curated tours, map collections, or regional studies.
+
+**Cross-links to consider:**
+- Relate important figures to `WHO` (explorers, leaders, indigenous peoples).
+- Reference key events in `WHEN` that took place in these locations.
+- Link to `WHY` for cultural, political, or environmental motivations tied to places.

--- a/ARKHIVE/What/Wikipedia_Topics/Health_and_Medicine/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Health_and_Medicine/README.md
@@ -1,0 +1,8 @@
+# Health and Medicine
+
+Medicine, public health, wellness, mental health, nutrition, and healthcare systems. Store overviews of medical disciplines, treatment approaches, and preventative care frameworks in this area.
+
+**Cross-links to consider:**
+- Connect practitioners, researchers, and institutions to `WHO`.
+- Tie breakthroughs or outbreaks to relevant eras in `WHEN`.
+- Reference ethical debates and motivations in `WHY` (e.g., bioethics, care philosophies).

--- a/ARKHIVE/What/Wikipedia_Topics/History_and_Events/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/History_and_Events/README.md
@@ -1,0 +1,8 @@
+# History and Events
+
+Chronological narratives, historical eras, revolutions, wars, social movements, and milestone happenings. Ideal for timelines, historiography projects, or event dossiers.
+
+**Cross-links to consider:**
+- Highlight key participants via `WHO` entries.
+- Link to primary locations in `WHERE`.
+- Tie causes and consequences into `WHY` and `HOW` (strategies, technologies, philosophies).

--- a/ARKHIVE/What/Wikipedia_Topics/Human_Activities/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Human_Activities/README.md
@@ -1,0 +1,8 @@
+# Human Activities
+
+Occupations, hobbies, sports, crafts, recreation, and everyday practices. Use this branch for outlining how people spend their time, develop skills, and collaborate in practical pursuits.
+
+**Cross-links to consider:**
+- Associate notable practitioners or organisations through `WHO`.
+- Link to `HOW` for methods, playbooks, and workflows.
+- Connect to cultural or societal motivations captured in `WHY` and `SOCIETY` notes.

--- a/ARKHIVE/What/Wikipedia_Topics/Mathematics_and_Logic/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Mathematics_and_Logic/README.md
@@ -1,0 +1,8 @@
+# Mathematics and Logic
+
+Pure and applied mathematics, theoretical computer science, logic systems, and problem-solving frameworks. Great for structuring definitions, theorem maps, proof techniques, and logical toolkits.
+
+**Cross-links to consider:**
+- Reference major mathematicians, logicians, and schools through `WHO`.
+- Connect applications to `TECHNOLOGY` or `NATURAL SCIENCES` notes elsewhere in `WHAT`.
+- Capture key historical developments in `WHEN` (e.g., math eras, paradigm shifts).

--- a/ARKHIVE/What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md
@@ -1,0 +1,8 @@
+# Natural and Physical Sciences
+
+Physics, chemistry, biology, earth sciences, astronomy, and interdisciplinary natural science fields. Collect survey notes, experiment summaries, and conceptual frameworks here.
+
+**Cross-links to consider:**
+- Link discoveries to the scientists (`WHO`) and labs behind them.
+- Tie fieldwork or study sites into `WHERE` (ecosystems, observatories, geological formations).
+- Capture timelines of discoveries within `WHEN`.

--- a/ARKHIVE/What/Wikipedia_Topics/People_and_Self/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/People_and_Self/README.md
@@ -1,0 +1,8 @@
+# People and Self
+
+Human identity, psychology, biographies, personal development, and interpersonal dynamics that focus on the individual perspective. Use this node for frameworks that explore what it means to be a person.
+
+**Cross-links to consider:**
+- Link notable individuals to detailed `WHO` entries.
+- Reference psychological theories or motivations catalogued in `WHY`.
+- Tie cultural or societal contexts back to `SOCIETY` and `WHERE`.

--- a/ARKHIVE/What/Wikipedia_Topics/Philosophy_and_Thinking/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Philosophy_and_Thinking/README.md
@@ -1,0 +1,8 @@
+# Philosophy and Thinking
+
+Philosophical traditions, schools of thought, epistemology, metaphysics, critical thinking, and reasoning frameworks. Organise mindsets, argument structures, and interpretive lenses here.
+
+**Cross-links to consider:**
+- Connect philosophers and thinkers through `WHO`.
+- Tie intellectual movements to periods in `WHEN` and locations in `WHERE`.
+- Link to `HOW` for analytical methods or dialectical practices derived from these schools.

--- a/ARKHIVE/What/Wikipedia_Topics/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/README.md
@@ -1,0 +1,25 @@
+# Wikipedia Topics Overlay
+
+This branch mirrors the top layer of [Wikipedia's contents structure](https://en.wikipedia.org/wiki/Wikipedia:Contents) so the Arkhive (and Door) can reuse familiar navigation categories. Each folder below introduces one high-level topic area. You can drill down by adding Markdown notes, outlines, or further folders inside each area.
+
+## How it fits the Mind Atlas
+- **Alignment with What** – These folders live under the `WHAT` branch because they organise knowledge domains and subject matter.
+- **Bridges to other branches** – When adding details, link to relevant WHO, WHERE, WHEN, WHY, or HOW entries so Door surfaces cross-branch context.
+- **Security / access** – Door’s node builder reads any Markdown inside `ARKHIVE/` (except README duplicates). Using this directory keeps permissions consistent with the rest of the Arkhive tree; no extra configuration is needed.
+
+## Top-level topic areas
+- [General Reference](General_Reference/README.md)
+- [Culture and the Arts](Culture_and_the_Arts/README.md)
+- [Geography and Places](Geography_and_Places/README.md)
+- [Health and Medicine](Health_and_Medicine/README.md)
+- [History and Events](History_and_Events/README.md)
+- [Human Activities](Human_Activities/README.md)
+- [Mathematics and Logic](Mathematics_and_Logic/README.md)
+- [Natural and Physical Sciences](Natural_and_Physical_Sciences/README.md)
+- [People and Self](People_and_Self/README.md)
+- [Philosophy and Thinking](Philosophy_and_Thinking/README.md)
+- [Religion and Belief Systems](Religion_and_Belief_Systems/README.md)
+- [Society and Social Sciences](Society_and_Social_Sciences/README.md)
+- [Technology and Applied Sciences](Technology_and_Applied_Sciences/README.md)
+
+Add new folders or notes under whichever heading fits best. Door will pick them up automatically the next time we rebuild its node cache.

--- a/ARKHIVE/What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md
@@ -1,0 +1,8 @@
+# Religion and Belief Systems
+
+Faith traditions, spiritual practices, mythologies, rituals, and worldviews. Map doctrinal structures, comparative religion studies, and lived experiences within this folder.
+
+**Cross-links to consider:**
+- Identify founders, leaders, and organisations in `WHO`.
+- Tie sacred sites and pilgrimage routes into `WHERE`.
+- Reference historical developments and reforms inside `WHEN`, and motivations in `WHY`.

--- a/ARKHIVE/What/Wikipedia_Topics/Society_and_Social_Sciences/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Society_and_Social_Sciences/README.md
@@ -1,0 +1,8 @@
+# Society and Social Sciences
+
+Sociology, anthropology, economics, political science, law, education, communication, and other studies focused on collective behaviour. Use this to outline institutions, social systems, and comparative studies.
+
+**Cross-links to consider:**
+- Link major organisations, governments, or communities through `WHO`.
+- Tie civic spaces, regions, and demographic patterns to `WHERE`.
+- Reference policies, ideologies, and motivations in `WHY`.

--- a/ARKHIVE/What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md
+++ b/ARKHIVE/What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md
@@ -1,0 +1,8 @@
+# Technology and Applied Sciences
+
+Engineering, information technology, industrial arts, applied physics, materials science, and practical innovations. Capture system architectures, toolkits, case studies, and implementation guides here.
+
+**Cross-links to consider:**
+- Reference inventors, companies, and project teams in `WHO`.
+- Connect manufacturing hubs or labs via `WHERE`.
+- Tie enabling methods or processes back to `HOW`, and motivations to `WHY`.

--- a/DATA/door/content/what.md
+++ b/DATA/door/content/what.md
@@ -1,6 +1,9 @@
 # What
 
-Concrete objects, abstract concepts, technologies, and knowledge domains
+Concrete objects, abstract concepts, technologies, and knowledge domains.
+
+## Wikipedia alignment overlay
+Use [Wikipedia Topics](Wikipedia_Topics/README.md) when you want to mirror the high-level navigation from Wikipedia’s contents page. It gives Door users a familiar starting point while keeping everything inside the existing `WHAT` security boundary.
 
 ## Child Rooms
 - **Arkhive What** (`what__arkhive-what-txt`)
@@ -10,6 +13,10 @@ Concrete objects, abstract concepts, technologies, and knowledge domains
 - **Knowledge Domains Disciplines** (`what__knowledge-domains-disciplines`)
 - **Natural World** (`what__natural-world`)
 - **What** (`what__what-md`)
+- **Wikipedia Topics** (`what__wikipedia-topics`)
+
+## Teleports
+- Wikipedia Topics → What/Wikipedia_Topics/README.md
 
 ---
 Source: ARKHIVE/What/README.md

--- a/DATA/door/content/what__wikipedia-topics.md
+++ b/DATA/door/content/what__wikipedia-topics.md
@@ -1,0 +1,65 @@
+# Wikipedia Topics
+
+# Wikipedia Topics Overlay
+
+This branch mirrors the top layer of [Wikipedia's contents structure](https://en.wikipedia.org/wiki/Wikipedia:Contents) so the Arkhive (and Door) can reuse familiar navigation categories. Each folder below introduces one high-level topic area. You can drill down by adding Markdown notes, outlines, or further folders inside each area.
+
+## How it fits the Mind Atlas
+- **Alignment with What** – These folders live under the `WHAT` branch because they organise knowledge domains and subject matter.
+- **Bridges to other branches** – When adding details, link to relevant WHO, WHERE, WHEN, WHY, or HOW entries so Door surfaces cross-branch context.
+- **Security / access** – Door’s node builder reads any Markdown inside `ARKHIVE/` (except README duplicates). Using this directory keeps permissions consistent with the rest of the Arkhive tree; no extra configuration is needed.
+
+## Top-level topic areas
+- [General Reference](General_Reference/README.md)
+- [Culture and the Arts](Culture_and_the_Arts/README.md)
+- [Geography and Places](Geography_and_Places/README.md)
+- [Health and Medicine](Health_and_Medicine/README.md)
+- [History and Events](History_and_Events/README.md)
+- [Human Activities](Human_Activities/README.md)
+- [Mathematics and Logic](Mathematics_and_Logic/README.md)
+- [Natural and Physical Sciences](Natural_and_Physical_Sciences/README.md)
+- [People and Self](People_and_Self/README.md)
+- [Philosophy and Thinking](Philosophy_and_Thinking/README.md)
+- [Religion and Belief Systems](Religion_and_Belief_Systems/README.md)
+- [Society and Social Sciences](Society_and_Social_Sciences/README.md)
+- [Technology and Applied Sciences](Technology_and_Applied_Sciences/README.md)
+
+Add new folders or notes under whichever heading fits best. Door will pick them up automatically the next time we rebuild its node cache.
+
+## Child Rooms
+- **Culture And The Arts** (`what__wikipedia-topics__culture-and-the-arts`)
+- **General Reference** (`what__wikipedia-topics__general-reference`)
+- **Geography And Places** (`what__wikipedia-topics__geography-and-places`)
+- **Health And Medicine** (`what__wikipedia-topics__health-and-medicine`)
+- **History And Events** (`what__wikipedia-topics__history-and-events`)
+- **Human Activities** (`what__wikipedia-topics__human-activities`)
+- **Mathematics And Logic** (`what__wikipedia-topics__mathematics-and-logic`)
+- **Natural And Physical Sciences** (`what__wikipedia-topics__natural-and-physical-sciences`)
+- **People And Self** (`what__wikipedia-topics__people-and-self`)
+- **Philosophy And Thinking** (`what__wikipedia-topics__philosophy-and-thinking`)
+- **Religion And Belief Systems** (`what__wikipedia-topics__religion-and-belief-systems`)
+- **Society And Social Sciences** (`what__wikipedia-topics__society-and-social-sciences`)
+- **Technology And Applied Sciences** (`what__wikipedia-topics__technology-and-applied-sciences`)
+
+## Teleports
+- [Wikipedia's contents structure](https://en.wikipedia.org/wiki/Wikipedia:Contents)
+- General Reference → What/Wikipedia_Topics/General_Reference/README.md
+- Culture and the Arts → What/Wikipedia_Topics/Culture_and_the_Arts/README.md
+- Geography and Places → What/Wikipedia_Topics/Geography_and_Places/README.md
+- Health and Medicine → What/Wikipedia_Topics/Health_and_Medicine/README.md
+- History and Events → What/Wikipedia_Topics/History_and_Events/README.md
+- Human Activities → What/Wikipedia_Topics/Human_Activities/README.md
+- Mathematics and Logic → What/Wikipedia_Topics/Mathematics_and_Logic/README.md
+- Natural and Physical Sciences → What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md
+- People and Self → What/Wikipedia_Topics/People_and_Self/README.md
+- Philosophy and Thinking → What/Wikipedia_Topics/Philosophy_and_Thinking/README.md
+- Religion and Belief Systems → What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md
+- Society and Social Sciences → What/Wikipedia_Topics/Society_and_Social_Sciences/README.md
+- Technology and Applied Sciences → What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__culture-and-the-arts.md
+++ b/DATA/door/content/what__wikipedia-topics__culture-and-the-arts.md
@@ -1,0 +1,15 @@
+# Culture and the Arts
+
+Creative expression, aesthetic movements, literature, music, visual arts, performing arts, design, and cultural heritage. Capture outlines of artistic traditions, notable works, or curation projects here.
+
+**Cross-links to consider:**
+- Link creators and organisations through `WHO` nodes (artists, studios, collectives).
+- Tie venues and cultural regions to `WHERE`.
+- Reference historical periods in `WHEN` to show when movements emerged.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Culture_and_the_Arts/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__general-reference.md
+++ b/DATA/door/content/what__wikipedia-topics__general-reference.md
@@ -1,0 +1,15 @@
+# General Reference
+
+High-level reference works and orientation tools—encyclopedias, dictionaries, atlases, timelines, bibliographies, glossaries, and general knowledge guides. Use this space to park navigation aids or overviews that do not belong to any single discipline.
+
+**Cross-links to add when you flesh this out:**
+- Connect to `WHERE` entries for atlases, maps, and gazetteers.
+- Link to `WHEN` timelines for chronological reference collections.
+- Reference `HOW` processes for research and study techniques tied to these sources.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/General_Reference/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__geography-and-places.md
+++ b/DATA/door/content/what__wikipedia-topics__geography-and-places.md
@@ -1,0 +1,15 @@
+# Geography and Places
+
+Physical and human geography, regions, countries, cities, landmarks, biomes, and spatial frameworks. Use this directory to sketch curated tours, map collections, or regional studies.
+
+**Cross-links to consider:**
+- Relate important figures to `WHO` (explorers, leaders, indigenous peoples).
+- Reference key events in `WHEN` that took place in these locations.
+- Link to `WHY` for cultural, political, or environmental motivations tied to places.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Geography_and_Places/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__health-and-medicine.md
+++ b/DATA/door/content/what__wikipedia-topics__health-and-medicine.md
@@ -1,0 +1,15 @@
+# Health and Medicine
+
+Medicine, public health, wellness, mental health, nutrition, and healthcare systems. Store overviews of medical disciplines, treatment approaches, and preventative care frameworks in this area.
+
+**Cross-links to consider:**
+- Connect practitioners, researchers, and institutions to `WHO`.
+- Tie breakthroughs or outbreaks to relevant eras in `WHEN`.
+- Reference ethical debates and motivations in `WHY` (e.g., bioethics, care philosophies).
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Health_and_Medicine/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__history-and-events.md
+++ b/DATA/door/content/what__wikipedia-topics__history-and-events.md
@@ -1,0 +1,15 @@
+# History and Events
+
+Chronological narratives, historical eras, revolutions, wars, social movements, and milestone happenings. Ideal for timelines, historiography projects, or event dossiers.
+
+**Cross-links to consider:**
+- Highlight key participants via `WHO` entries.
+- Link to primary locations in `WHERE`.
+- Tie causes and consequences into `WHY` and `HOW` (strategies, technologies, philosophies).
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/History_and_Events/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__human-activities.md
+++ b/DATA/door/content/what__wikipedia-topics__human-activities.md
@@ -1,0 +1,15 @@
+# Human Activities
+
+Occupations, hobbies, sports, crafts, recreation, and everyday practices. Use this branch for outlining how people spend their time, develop skills, and collaborate in practical pursuits.
+
+**Cross-links to consider:**
+- Associate notable practitioners or organisations through `WHO`.
+- Link to `HOW` for methods, playbooks, and workflows.
+- Connect to cultural or societal motivations captured in `WHY` and `SOCIETY` notes.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Human_Activities/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__mathematics-and-logic.md
+++ b/DATA/door/content/what__wikipedia-topics__mathematics-and-logic.md
@@ -1,0 +1,15 @@
+# Mathematics and Logic
+
+Pure and applied mathematics, theoretical computer science, logic systems, and problem-solving frameworks. Great for structuring definitions, theorem maps, proof techniques, and logical toolkits.
+
+**Cross-links to consider:**
+- Reference major mathematicians, logicians, and schools through `WHO`.
+- Connect applications to `TECHNOLOGY` or `NATURAL SCIENCES` notes elsewhere in `WHAT`.
+- Capture key historical developments in `WHEN` (e.g., math eras, paradigm shifts).
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Mathematics_and_Logic/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__natural-and-physical-sciences.md
+++ b/DATA/door/content/what__wikipedia-topics__natural-and-physical-sciences.md
@@ -1,0 +1,15 @@
+# Natural and Physical Sciences
+
+Physics, chemistry, biology, earth sciences, astronomy, and interdisciplinary natural science fields. Collect survey notes, experiment summaries, and conceptual frameworks here.
+
+**Cross-links to consider:**
+- Link discoveries to the scientists (`WHO`) and labs behind them.
+- Tie fieldwork or study sites into `WHERE` (ecosystems, observatories, geological formations).
+- Capture timelines of discoveries within `WHEN`.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__people-and-self.md
+++ b/DATA/door/content/what__wikipedia-topics__people-and-self.md
@@ -1,0 +1,15 @@
+# People and Self
+
+Human identity, psychology, biographies, personal development, and interpersonal dynamics that focus on the individual perspective. Use this node for frameworks that explore what it means to be a person.
+
+**Cross-links to consider:**
+- Link notable individuals to detailed `WHO` entries.
+- Reference psychological theories or motivations catalogued in `WHY`.
+- Tie cultural or societal contexts back to `SOCIETY` and `WHERE`.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/People_and_Self/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__philosophy-and-thinking.md
+++ b/DATA/door/content/what__wikipedia-topics__philosophy-and-thinking.md
@@ -1,0 +1,15 @@
+# Philosophy and Thinking
+
+Philosophical traditions, schools of thought, epistemology, metaphysics, critical thinking, and reasoning frameworks. Organise mindsets, argument structures, and interpretive lenses here.
+
+**Cross-links to consider:**
+- Connect philosophers and thinkers through `WHO`.
+- Tie intellectual movements to periods in `WHEN` and locations in `WHERE`.
+- Link to `HOW` for analytical methods or dialectical practices derived from these schools.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Philosophy_and_Thinking/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__religion-and-belief-systems.md
+++ b/DATA/door/content/what__wikipedia-topics__religion-and-belief-systems.md
@@ -1,0 +1,15 @@
+# Religion and Belief Systems
+
+Faith traditions, spiritual practices, mythologies, rituals, and worldviews. Map doctrinal structures, comparative religion studies, and lived experiences within this folder.
+
+**Cross-links to consider:**
+- Identify founders, leaders, and organisations in `WHO`.
+- Tie sacred sites and pilgrimage routes into `WHERE`.
+- Reference historical developments and reforms inside `WHEN`, and motivations in `WHY`.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__society-and-social-sciences.md
+++ b/DATA/door/content/what__wikipedia-topics__society-and-social-sciences.md
@@ -1,0 +1,15 @@
+# Society and Social Sciences
+
+Sociology, anthropology, economics, political science, law, education, communication, and other studies focused on collective behaviour. Use this to outline institutions, social systems, and comparative studies.
+
+**Cross-links to consider:**
+- Link major organisations, governments, or communities through `WHO`.
+- Tie civic spaces, regions, and demographic patterns to `WHERE`.
+- Reference policies, ideologies, and motivations in `WHY`.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Society_and_Social_Sciences/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/content/what__wikipedia-topics__technology-and-applied-sciences.md
+++ b/DATA/door/content/what__wikipedia-topics__technology-and-applied-sciences.md
@@ -1,0 +1,15 @@
+# Technology and Applied Sciences
+
+Engineering, information technology, industrial arts, applied physics, materials science, and practical innovations. Capture system architectures, toolkits, case studies, and implementation guides here.
+
+**Cross-links to consider:**
+- Reference inventors, companies, and project teams in `WHO`.
+- Connect manufacturing hubs or labs via `WHERE`.
+- Tie enabling methods or processes back to `HOW`, and motivations to `WHY`.
+
+---
+Source: ARKHIVE/What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md
+
+/// === PROPROMPT:BEGIN ===
+see: MIND/ProPrompts/Library/DOOR-Seeds.md
+/// === PROPROMPT:END ===

--- a/DATA/door/index.json
+++ b/DATA/door/index.json
@@ -1,6 +1,6 @@
 {
     "schemaVersion": "1.0.0",
-    "generatedAt": "2025-09-28T09:43:28+00:00",
+    "generatedAt": "2025-10-04T02:36:04+00:00",
     "root": "mind-atlas",
     "branches": [
         {
@@ -35,8 +35,8 @@
         }
     ],
     "counts": {
-        "nodes": 1345,
-        "links": 245
+        "nodes": 1359,
+        "links": 260
     },
     "contentBase": "DATA/door/content"
 }

--- a/DATA/door/nodes.json
+++ b/DATA/door/nodes.json
@@ -1,6 +1,6 @@
 {
     "schemaVersion": "1.0.0",
-    "generatedAt": "2025-09-28T09:43:28+00:00",
+    "generatedAt": "2025-10-04T02:36:04+00:00",
     "nodes": [
         {
             "id": "arkhive-md",
@@ -1951,9 +1951,16 @@
                 "what__concepts-ideas",
                 "what__knowledge-domains-disciplines",
                 "what__natural-world",
-                "what__what-md"
+                "what__what-md",
+                "what__wikipedia-topics"
             ],
-            "links": [],
+            "links": [
+                {
+                    "title": "Wikipedia Topics",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/README.md"
+                }
+            ],
             "contentPath": "DATA/door/content/what.md",
             "sourcePath": "ARKHIVE/What/README.md",
             "missing": false
@@ -6902,6 +6909,245 @@
             "links": [],
             "contentPath": "DATA/door/content/what__what-md.md",
             "sourcePath": "ARKHIVE/What/What.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics",
+            "title": "Wikipedia Topics",
+            "branch": "What",
+            "kind": "dir",
+            "children": [
+                "what__wikipedia-topics__culture-and-the-arts",
+                "what__wikipedia-topics__general-reference",
+                "what__wikipedia-topics__geography-and-places",
+                "what__wikipedia-topics__health-and-medicine",
+                "what__wikipedia-topics__history-and-events",
+                "what__wikipedia-topics__human-activities",
+                "what__wikipedia-topics__mathematics-and-logic",
+                "what__wikipedia-topics__natural-and-physical-sciences",
+                "what__wikipedia-topics__people-and-self",
+                "what__wikipedia-topics__philosophy-and-thinking",
+                "what__wikipedia-topics__religion-and-belief-systems",
+                "what__wikipedia-topics__society-and-social-sciences",
+                "what__wikipedia-topics__technology-and-applied-sciences"
+            ],
+            "links": [
+                {
+                    "title": "Wikipedia's contents structure",
+                    "type": "url",
+                    "target": "https://en.wikipedia.org/wiki/Wikipedia:Contents"
+                },
+                {
+                    "title": "General Reference",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/General_Reference/README.md"
+                },
+                {
+                    "title": "Culture and the Arts",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Culture_and_the_Arts/README.md"
+                },
+                {
+                    "title": "Geography and Places",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Geography_and_Places/README.md"
+                },
+                {
+                    "title": "Health and Medicine",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Health_and_Medicine/README.md"
+                },
+                {
+                    "title": "History and Events",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/History_and_Events/README.md"
+                },
+                {
+                    "title": "Human Activities",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Human_Activities/README.md"
+                },
+                {
+                    "title": "Mathematics and Logic",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Mathematics_and_Logic/README.md"
+                },
+                {
+                    "title": "Natural and Physical Sciences",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md"
+                },
+                {
+                    "title": "People and Self",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/People_and_Self/README.md"
+                },
+                {
+                    "title": "Philosophy and Thinking",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Philosophy_and_Thinking/README.md"
+                },
+                {
+                    "title": "Religion and Belief Systems",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md"
+                },
+                {
+                    "title": "Society and Social Sciences",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Society_and_Social_Sciences/README.md"
+                },
+                {
+                    "title": "Technology and Applied Sciences",
+                    "type": "path",
+                    "target": "What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md"
+                }
+            ],
+            "contentPath": "DATA/door/content/what__wikipedia-topics.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__culture-and-the-arts",
+            "title": "Culture And The Arts",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__culture-and-the-arts.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Culture_and_the_Arts/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__general-reference",
+            "title": "General Reference",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__general-reference.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/General_Reference/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__geography-and-places",
+            "title": "Geography And Places",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__geography-and-places.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Geography_and_Places/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__health-and-medicine",
+            "title": "Health And Medicine",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__health-and-medicine.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Health_and_Medicine/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__history-and-events",
+            "title": "History And Events",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__history-and-events.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/History_and_Events/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__human-activities",
+            "title": "Human Activities",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__human-activities.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Human_Activities/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__mathematics-and-logic",
+            "title": "Mathematics And Logic",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__mathematics-and-logic.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Mathematics_and_Logic/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__natural-and-physical-sciences",
+            "title": "Natural And Physical Sciences",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__natural-and-physical-sciences.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Natural_and_Physical_Sciences/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__people-and-self",
+            "title": "People And Self",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__people-and-self.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/People_and_Self/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__philosophy-and-thinking",
+            "title": "Philosophy And Thinking",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__philosophy-and-thinking.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Philosophy_and_Thinking/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__religion-and-belief-systems",
+            "title": "Religion And Belief Systems",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__religion-and-belief-systems.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Religion_and_Belief_Systems/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__society-and-social-sciences",
+            "title": "Society And Social Sciences",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__society-and-social-sciences.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Society_and_Social_Sciences/README.md",
+            "missing": false
+        },
+        {
+            "id": "what__wikipedia-topics__technology-and-applied-sciences",
+            "title": "Technology And Applied Sciences",
+            "branch": "What",
+            "kind": "dir",
+            "children": [],
+            "links": [],
+            "contentPath": "DATA/door/content/what__wikipedia-topics__technology-and-applied-sciences.md",
+            "sourcePath": "ARKHIVE/What/Wikipedia_Topics/Technology_and_Applied_Sciences/README.md",
             "missing": false
         },
         {


### PR DESCRIPTION
## Summary
- add a Wikipedia Topics branch under WHAT that mirrors the top-level sections from Wikipedia's contents page
- document each topic folder with guidance on how to cross-link it to other Arkhive branches so Door users can explore the structure safely
- regenerate Door node data so the new branch and its children are available to the UI

## Testing
- php scripts/build_door_nodes.php

------
https://chatgpt.com/codex/tasks/task_e_68e08745b034832c89d4ab9c4c7d4bb1