### PR TITLE
Preserve optional door link metadata

### DIFF
--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -427,7 +427,8 @@ function door_clean_link($link){
   $clean=['target'=>$target,'title'=>$title,'type'=>$type];
   $id=trim((string)($link['id'] ?? ''));
   if($id!=='') $clean['id']=$id;
-  foreach(['path','nodeKind','direction'] as $extra){
+  $optionalKeys=['path','nodeKind','direction','label','icon','color','tileKind'];
+  foreach($optionalKeys as $extra){
     if(array_key_exists($extra,$link)) $clean[$extra]=$link[$extra];
   }
   return $clean;
@@ -608,11 +609,8 @@ function door_handle_data(){
   if(!empty($node['links']) && is_array($node['links'])){
     foreach($node['links'] as $link){
       if(!is_array($link)) continue;
-      $links[]=[
-        'target'=>$link['target'] ?? '',
-        'title'=>$link['title'] ?? '',
-        'type'=>$link['type'] ?? ''
-      ];
+      $clean=door_clean_link($link);
+      if($clean) $links[]=$clean;
     }
   }
   $crumb=door_build_breadcrumb($root,$node['id'] ?? '');


### PR DESCRIPTION
## Summary
- keep optional link metadata fields when cleaning and returning door links from the backend
- update the Door Builder UI to retain link metadata while rendering, editing, and saving links
- ensure link edits merge existing metadata so optional properties round-trip correctly

## Testing
- php -l CLOUD/cloud.php

------
https://chatgpt.com/codex/tasks/task_e_68e0a0864028832cac92451975c78fc9