### PR TITLE
Add custom dialog for creating child rooms

### DIFF
--- a/CLOUD/assets/css/door.css
+++ b/CLOUD/assets/css/door.css
@@ -593,6 +593,115 @@ header a:hover {
   display: flex;
 }
 
+.door-child-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(4px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  padding: 1.5rem;
+}
+
+.door-child-dialog.active {
+  display: flex;
+}
+
+.door-child-dialog[hidden] {
+  display: none !important;
+}
+
+.door-child-dialog-content {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  width: min(360px, 100%);
+  padding: 1.5rem;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-child-dialog h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  color: #e2e8f0;
+}
+
+.door-child-dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-child-dialog-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  color: #cbd5f5;
+  font-size: 0.9rem;
+}
+
+.door-child-dialog-form input {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 0.65rem 0.75rem;
+  font-size: 1rem;
+}
+
+.door-child-dialog-form input:focus {
+  outline: none;
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+}
+
+.door-child-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.door-child-dialog-actions button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.door-child-dialog-actions button:disabled {
+  opacity: 0.6;
+  cursor: progress;
+}
+
+.door-child-dialog-cancel {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+}
+
+.door-child-dialog-cancel:hover,
+.door-child-dialog-cancel:focus {
+  background: rgba(148, 163, 184, 0.35);
+  outline: none;
+}
+
+.door-child-dialog-create {
+  background: rgba(34, 197, 94, 0.25);
+  color: #4ade80;
+}
+
+.door-child-dialog-create:hover,
+.door-child-dialog-create:focus {
+  background: rgba(34, 197, 94, 0.35);
+  outline: none;
+}
+
 .door-attach-dialog {
   background: rgba(15, 23, 42, 0.95);
   border: 1px solid rgba(148, 163, 184, 0.25);

--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -879,6 +879,20 @@ function door_render_shell($title){
     </div>
     <div class="door-panel" id="door-rail-wrap"></div>
     <div class="door-panel" id="door-search-wrap"></div>
+    <div class="door-child-dialog" id="door-child-dialog" hidden>
+      <div class="door-child-dialog-content" role="dialog" aria-modal="true" aria-labelledby="door-child-title">
+        <h2 id="door-child-title">Create a room</h2>
+        <form class="door-child-dialog-form" id="door-child-form">
+          <label for="door-child-name">Room name
+            <input id="door-child-name" name="title" value="New Room" placeholder="New Room" autocomplete="off" required>
+          </label>
+          <div class="door-child-dialog-actions">
+            <button type="button" class="door-child-dialog-cancel" id="door-child-cancel">Cancel</button>
+            <button type="submit" class="door-child-dialog-create" id="door-child-create">Create</button>
+          </div>
+        </form>
+      </div>
+    </div>
   </main>
   <script>
     window.__DOOR_BOOTSTRAP__ = {


### PR DESCRIPTION
## Summary
- add markup for a dedicated add-room dialog in the Door builder shell
- style the new dialog overlay and buttons to match the app theme
- replace the window.prompt flow with dialog open/submit/cancel logic that calls the existing create request

## Testing
- python CLOUD assets create-room CLI script

------
https://chatgpt.com/codex/tasks/task_e_68e0cadaf090832c993c2a80ee271a3d