### PR TITLE
Refresh Door styling and harden room creation fallback

### DIFF
--- a/CLOUD/assets/css/door.css
+++ b/CLOUD/assets/css/door.css
@@ -1,8 +1,8 @@
 body {
   margin: 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #0f172a;
-  color: #e2e8f0;
+  background: #f8fafc;
+  color: #0f172a;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -18,8 +18,9 @@ header {
   flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
-  background: #1e293b;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  background: #ffffff;
+  border-bottom: 1px solid #e2e8f0;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
 }
 
 header h1 {
@@ -28,17 +29,27 @@ header h1 {
   flex: 1;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #38bdf8;
+  color: #0f172a;
 }
 
 header a {
-  color: #38bdf8;
+  color: #1d4ed8;
   text-decoration: none;
   font-weight: 600;
+  border: 1px solid #c7d2fe;
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  background: #eef2ff;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-header a:hover {
-  text-decoration: underline;
+header a:hover,
+header a:focus-visible {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+  outline: none;
 }
 
 .door-shell {
@@ -46,16 +57,17 @@ header a:hover {
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 1rem;
+  padding: 1.5rem;
+  width: min(1200px, 100%);
+  margin: 0 auto;
 }
 
 .door-panel {
-  background: rgba(15, 23, 42, 0.65);
+  background: #ffffff;
   border-radius: 1rem;
-  padding: 1rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.5);
+  padding: 1.25rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
 }
 
 .door-grid {
@@ -69,29 +81,30 @@ header a:hover {
   position: relative;
 }
 
+
 .door-tile {
   aspect-ratio: 1 / 1;
-  background: linear-gradient(135deg, #334155, #1e293b);
+  background: linear-gradient(135deg, #eef2ff, #dbeafe);
   border: 2px solid transparent;
   border-radius: 1rem;
-  color: #f8fafc;
-  font-size: 1.125rem;
+  color: #0f172a;
+  font-size: 1.05rem;
   font-weight: 600;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 0.5rem;
-  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.45);
-  transition: transform 0.2s, border-color 0.2s, box-shadow 0.2s;
+  padding: 0.75rem;
+  box-shadow: 0 12px 25px rgba(148, 163, 184, 0.22);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
   touch-action: manipulation;
 }
 
 .door-tile:focus,
 .door-tile:hover {
   transform: translateY(-4px);
-  border-color: #38bdf8;
-  box-shadow: 0 12px 20px rgba(56, 189, 248, 0.35);
+  border-color: #2563eb;
+  box-shadow: 0 16px 35px rgba(37, 99, 235, 0.25);
   outline: none;
 }
 
@@ -106,8 +119,8 @@ header a:hover {
   font-weight: 600;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  background: rgba(56, 189, 248, 0.25);
-  color: #38bdf8;
+  background: rgba(37, 99, 235, 0.15);
+  color: #1d4ed8;
   cursor: pointer;
   transition: background 0.2s, transform 0.2s;
 }
@@ -123,7 +136,7 @@ header a:hover {
 
 .door-tile-action:hover,
 .door-tile-action:focus {
-  background: rgba(56, 189, 248, 0.4);
+  background: rgba(59, 130, 246, 0.25);
   outline: none;
   transform: translateY(-1px);
 }
@@ -133,9 +146,10 @@ header a:hover {
   top: 2.6rem;
   right: 0.5rem;
   min-width: 9rem;
-  background: rgba(15, 23, 42, 0.96);
+  background: #ffffff;
   border-radius: 0.75rem;
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.5);
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.12);
+  border: 1px solid #e2e8f0;
   padding: 0.35rem 0;
   display: none;
   flex-direction: column;
@@ -149,30 +163,30 @@ header a:hover {
 .door-tile-menu-item {
   background: none;
   border: none;
-  padding: 0.4rem 0.85rem;
-  font-size: 0.8rem;
-  color: #e2e8f0;
+  padding: 0.45rem 0.95rem;
+  font-size: 0.85rem;
+  color: #1f2937;
   text-align: left;
   cursor: pointer;
-  transition: background 0.2s, color 0.2s;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .door-tile-menu-item:hover,
 .door-tile-menu-item:focus {
-  background: rgba(56, 189, 248, 0.35);
-  color: #0f172a;
+  background: #eff6ff;
+  color: #1d4ed8;
   outline: none;
 }
 
 .door-tile.door-add {
-  background: rgba(56, 189, 248, 0.15);
-  color: #38bdf8;
+  background: linear-gradient(135deg, #e0f2fe, #bfdbfe);
+  color: #1d4ed8;
   font-size: 2rem;
 }
 
 .door-tile.door-search {
-  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
-  color: #0f172a;
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #f8fafc;
 }
 
 .door-tile.door-search span {
@@ -198,7 +212,7 @@ header a:hover {
 .door-breadcrumb button {
   background: none;
   border: none;
-  color: #38bdf8;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
   padding: 0.25rem 0.6rem;
@@ -207,15 +221,15 @@ header a:hover {
 
 .door-breadcrumb button:hover,
 .door-breadcrumb button:focus {
-  background: rgba(56, 189, 248, 0.15);
+  background: #e0f2fe;
   outline: none;
 }
 
 .door-crumb-classic {
   border: none;
   border-radius: 0.5rem;
-  background: rgba(56, 189, 248, 0.12);
-  color: #bae6fd;
+  background: #e0f2fe;
+  color: #0369a1;
   cursor: pointer;
   padding: 0.2rem 0.55rem;
   font-size: 0.7rem;
@@ -226,7 +240,7 @@ header a:hover {
 
 .door-crumb-classic:hover,
 .door-crumb-classic:focus {
-  background: rgba(56, 189, 248, 0.25);
+  background: #bae6fd;
   color: #0f172a;
   outline: none;
 }
@@ -240,7 +254,7 @@ header a:hover {
 .door-node-link {
   background: none;
   border: none;
-  color: #38bdf8;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
@@ -251,11 +265,11 @@ header a:hover {
 }
 
 .door-node-link:hover {
-  text-decoration: underline;
+  background: #e0f2fe;
 }
 
 .door-node-link:focus {
-  outline: 2px solid rgba(56, 189, 248, 0.45);
+  outline: 2px solid rgba(59, 130, 246, 0.35);
   outline-offset: 2px;
 }
 
@@ -280,19 +294,36 @@ header a:hover {
   min-width: 200px;
   padding: 0.6rem 0.8rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(15, 23, 42, 0.8);
-  color: #f8fafc;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.door-search input:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
 }
 
 .door-search button {
   padding: 0.6rem 1rem;
   border-radius: 0.75rem;
   border: none;
-  background: #38bdf8;
-  color: #0f172a;
+  background: #2563eb;
+  color: #f8fafc;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
+  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.door-search button:hover,
+.door-search button:focus-visible {
+  background: #1d4ed8;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.3);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .door-chip {
@@ -302,9 +333,9 @@ header a:hover {
   gap: 0.35rem;
   padding: 0.35rem 0.85rem;
   border-radius: 9999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(15, 23, 42, 0.75);
-  color: #f8fafc;
+  border: 1px solid #cbd5f5;
+  background: #eef2ff;
+  color: #1d4ed8;
   font-weight: 600;
   font-size: 0.85rem;
   cursor: pointer;
@@ -315,15 +346,16 @@ header a:hover {
 
 .door-chip:hover,
 .door-chip:focus {
-  border-color: rgba(56, 189, 248, 0.5);
-  background: rgba(56, 189, 248, 0.15);
+  border-color: #93c5fd;
+  background: #dbeafe;
   transform: translateY(-1px);
   outline: none;
 }
 
 .door-chip-file {
-  border-color: rgba(248, 113, 113, 0.4);
-  color: #fca5a5;
+  border-color: #fecaca;
+  background: #fee2e2;
+  color: #b91c1c;
 }
 
 .door-search-quick {
@@ -342,7 +374,7 @@ header a:hover {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(148, 163, 184, 0.8);
+  color: #64748b;
 }
 
 .door-search-chips {
@@ -353,13 +385,13 @@ header a:hover {
 
 .door-search-empty {
   font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.8);
+  color: #64748b;
 }
 
 .door-status {
   min-height: 1.5rem;
   font-size: 0.9rem;
-  color: #38bdf8;
+  color: #0f172a;
 }
 
 .door-status.error {
@@ -377,7 +409,7 @@ header a:hover {
   flex-direction: column;
   gap: 0.35rem;
   font-size: 0.85rem;
-  color: #94a3b8;
+  color: #475569;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -385,16 +417,24 @@ header a:hover {
 .door-editor input,
 .door-editor textarea {
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #0f172a;
   padding: 0.6rem 0.75rem;
   font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .door-editor textarea {
   min-height: 120px;
   resize: vertical;
+}
+
+.door-editor input:focus,
+.door-editor textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
 }
 
 .door-editor-actions {
@@ -407,25 +447,39 @@ header a:hover {
   flex: 1 1 120px;
   padding: 0.75rem;
   border-radius: 0.75rem;
-  border: none;
+  border: 1px solid #dbeafe;
   font-weight: 600;
   cursor: pointer;
   touch-action: manipulation;
+  background: #eef2ff;
+  color: #1d4ed8;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-save {
-  background: #38bdf8;
-  color: #0f172a;
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
 }
 
 .door-new {
-  background: rgba(34, 197, 94, 0.2);
-  color: #4ade80;
+  background: #dcfce7;
+  border-color: #bbf7d0;
+  color: #166534;
 }
 
 .door-delete {
-  background: rgba(248, 113, 113, 0.2);
-  color: #f87171;
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.door-editor-actions button:hover,
+.door-editor-actions button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(148, 163, 184, 0.2);
+  outline: none;
 }
 
 .door-links-block {
@@ -446,23 +500,27 @@ header a:hover {
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #94a3b8;
+  color: #475569;
 }
 
 .door-link-attach {
-  border: none;
+  border: 1px solid #dbeafe;
   padding: 0.5rem 0.85rem;
   border-radius: 0.75rem;
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
+  background: #eef2ff;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
   touch-action: manipulation;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-link-attach:hover,
 .door-link-attach:focus {
-  background: rgba(56, 189, 248, 0.35);
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.35);
+  transform: translateY(-1px);
   outline: none;
 }
 
@@ -479,17 +537,18 @@ header a:hover {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  background: rgba(15, 23, 42, 0.75);
+  background: #f8fafc;
   border-radius: 0.75rem;
   padding: 0.5rem 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.06);
 }
 
 .door-link-meta {
   display: flex;
   flex-direction: column;
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .door-link-meta span {
@@ -505,50 +564,58 @@ header a:hover {
 .door-link-classic,
 .door-link-edit,
 .door-link-remove {
-  border: none;
+  border: 1px solid transparent;
   padding: 0.4rem 0.75rem;
   border-radius: 0.75rem;
   cursor: pointer;
   font-weight: 600;
   touch-action: manipulation;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
 }
 
 .door-link-classic {
-  background: rgba(56, 189, 248, 0.12);
-  color: #bae6fd;
+  background: #eef2ff;
+  border-color: #dbeafe;
+  color: #1d4ed8;
 }
 
 .door-link-classic:hover,
-.door-link-classic:focus {
-  background: rgba(56, 189, 248, 0.25);
-  color: #0f172a;
+.door-link-classic:focus-visible {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.3);
+  transform: translateY(-1px);
   outline: none;
 }
 
 .door-link-edit {
-  background: rgba(56, 189, 248, 0.18);
-  color: #38bdf8;
+  background: #ecfeff;
+  border-color: #bae6fd;
+  color: #0369a1;
 }
 
 .door-link-edit:hover,
-.door-link-edit:focus {
-  background: rgba(56, 189, 248, 0.3);
+.door-link-edit:focus-visible {
+  background: #bae6fd;
+  border-color: #7dd3fc;
+  box-shadow: 0 8px 18px rgba(125, 211, 252, 0.3);
+  transform: translateY(-1px);
   outline: none;
 }
 
 .door-link-remove {
-  background: rgba(248, 113, 113, 0.2);
-  color: #f87171;
-  border: none;
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
 }
 
-.door-link-remove:hover {
-  background: rgba(248, 113, 113, 0.3);
-}
-
-.door-link-remove:focus {
-  outline: 2px solid rgba(248, 113, 113, 0.4);
-  outline-offset: 2px;
+.door-link-remove:hover,
+.door-link-remove:focus-visible {
+  background: #fecaca;
+  border-color: #fca5a5;
+  box-shadow: 0 8px 18px rgba(248, 113, 113, 0.3);
+  transform: translateY(-1px);
+  outline: none;
 }
 
 .door-layout {
@@ -614,12 +681,12 @@ header a:hover {
 }
 
 .door-child-dialog-content {
-  background: rgba(15, 23, 42, 0.95);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
   border-radius: 1rem;
   width: min(360px, 100%);
   padding: 1.5rem;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.6);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -628,7 +695,7 @@ header a:hover {
 .door-child-dialog h2 {
   margin: 0;
   font-size: 1.15rem;
-  color: #e2e8f0;
+  color: #0f172a;
 }
 
 .door-child-dialog-form {
@@ -641,23 +708,24 @@ header a:hover {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  color: #cbd5f5;
+  color: #475569;
   font-size: 0.9rem;
 }
 
 .door-child-dialog-form input {
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid #cbd5f5;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.85);
-  color: #f8fafc;
+  background: #ffffff;
+  color: #0f172a;
   padding: 0.65rem 0.75rem;
   font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .door-child-dialog-form input:focus {
   outline: none;
-  border-color: #38bdf8;
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
 }
 
 .door-child-dialog-actions {
@@ -667,12 +735,15 @@ header a:hover {
 }
 
 .door-child-dialog-actions button {
-  border: none;
+  border: 1px solid #dbeafe;
   border-radius: 0.75rem;
   padding: 0.65rem 1rem;
   font-weight: 600;
   cursor: pointer;
   touch-action: manipulation;
+  background: #eef2ff;
+  color: #1d4ed8;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-child-dialog-actions button:disabled {
@@ -680,38 +751,36 @@ header a:hover {
   cursor: progress;
 }
 
-.door-child-dialog-cancel {
-  background: rgba(148, 163, 184, 0.2);
-  color: #e2e8f0;
+.door-child-dialog-actions button:hover,
+.door-child-dialog-actions button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px rgba(148, 163, 184, 0.2);
+  outline: none;
 }
 
-.door-child-dialog-cancel:hover,
-.door-child-dialog-cancel:focus {
-  background: rgba(148, 163, 184, 0.35);
-  outline: none;
+.door-child-dialog-cancel {
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+  color: #475569;
 }
 
 .door-child-dialog-create {
-  background: rgba(34, 197, 94, 0.25);
-  color: #4ade80;
-}
-
-.door-child-dialog-create:hover,
-.door-child-dialog-create:focus {
-  background: rgba(34, 197, 94, 0.35);
-  outline: none;
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
 }
 
 .door-attach-dialog {
-  background: rgba(15, 23, 42, 0.95);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
   border-radius: 1rem;
   width: min(640px, 100%);
   max-height: 90vh;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.6);
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.18);
 }
 
 .door-attach-body {
@@ -734,14 +803,14 @@ header a:hover {
 }
 
 .door-attach-type {
-  border: 1px solid rgba(148, 163, 184, 0.3);
+  border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.75);
-  color: #e2e8f0;
+  background: #f8fafc;
+  color: #0f172a;
   padding: 0.6rem 0.75rem;
   text-align: left;
   cursor: pointer;
-  transition: border 0.2s, background 0.2s;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .door-attach-type strong {
@@ -752,18 +821,23 @@ header a:hover {
 .door-attach-type span {
   display: block;
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: #64748b;
   margin-top: 0.25rem;
 }
 
 .door-attach-type.active {
-  border-color: rgba(56, 189, 248, 0.6);
-  background: rgba(56, 189, 248, 0.2);
+  border-color: #93c5fd;
+  background: #dbeafe;
+  box-shadow: 0 10px 24px rgba(147, 197, 253, 0.25);
 }
 
-.door-attach-type:focus {
+.door-attach-type:focus-visible,
+.door-attach-type:hover {
   outline: none;
-  border-color: rgba(56, 189, 248, 0.8);
+  border-color: #2563eb;
+  background: #eff6ff;
+  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.2);
+  transform: translateY(-2px);
 }
 
 .door-attach-field label {
@@ -771,7 +845,7 @@ header a:hover {
   font-size: 0.8rem;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: #94a3b8;
+  color: #475569;
   margin-bottom: 0.35rem;
 }
 
@@ -780,9 +854,17 @@ header a:hover {
   width: 100%;
   padding: 0.6rem 0.75rem;
   border-radius: 0.75rem;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.8);
-  color: #f8fafc;
+  border: 1px solid #cbd5f5;
+  background: #ffffff;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.door-attach-field input:focus,
+.door-attach-field textarea:focus {
+  outline: none;
+  border-color: #2563eb;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
 }
 
 .door-attach-pane {
@@ -807,22 +889,26 @@ header a:hover {
 .door-attach-path button {
   padding: 0.6rem 1rem;
   border-radius: 0.75rem;
-  border: none;
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
+  border: 1px solid #dbeafe;
+  background: #eef2ff;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-attach-path button:hover,
 .door-attach-path button:focus {
-  background: rgba(56, 189, 248, 0.35);
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.3);
+  transform: translateY(-1px);
   outline: none;
 }
 
 .door-attach-hint {
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .door-attach-relations {
@@ -840,36 +926,38 @@ header a:hover {
 }
 
 .door-attach-relations-list button {
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.75);
-  color: #e2e8f0;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #0f172a;
   border-radius: 0.6rem;
   padding: 0.45rem 0.6rem;
   text-align: left;
   cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 .door-attach-relations-list button.active {
-  border-color: rgba(56, 189, 248, 0.6);
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
+  border-color: #93c5fd;
+  background: #dbeafe;
+  color: #1d4ed8;
+  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.25);
 }
 
 .door-attach-relations-empty {
   font-size: 0.75rem;
-  color: #94a3b8;
+  color: #64748b;
 }
 
 .door-attach-structure-preview {
   max-height: 160px;
   overflow: auto;
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
   padding: 0.75rem;
-  background: rgba(15, 23, 42, 0.65);
+  background: #f8fafc;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   font-size: 0.75rem;
-  color: #cbd5f5;
+  color: #0f172a;
   white-space: pre-wrap;
 }
 
@@ -878,25 +966,31 @@ header a:hover {
   justify-content: flex-end;
   gap: 0.5rem;
   padding: 1rem 1.5rem 1.5rem;
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  border-top: 1px solid #e2e8f0;
 }
 
 .door-attach-actions button {
   padding: 0.6rem 1.1rem;
   border-radius: 0.75rem;
-  border: none;
+  border: 1px solid #dbeafe;
   font-weight: 600;
   cursor: pointer;
+  background: #eef2ff;
+  color: #1d4ed8;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-attach-cancel {
-  background: rgba(148, 163, 184, 0.25);
-  color: #e2e8f0;
+  background: #f1f5f9;
+  border-color: #e2e8f0;
+  color: #475569;
 }
 
 .door-attach-submit {
-  background: rgba(56, 189, 248, 0.35);
-  color: #0f172a;
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #f8fafc;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
 }
 
 .door-attach-submit:disabled {
@@ -904,10 +998,17 @@ header a:hover {
   cursor: not-allowed;
 }
 
+.door-attach-actions button:hover,
+.door-attach-actions button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
+  outline: none;
+}
+
 .door-attach-browser {
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid #e2e8f0;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.85);
+  background: #f8fafc;
   padding: 0.75rem;
   display: none;
   flex-direction: column;
@@ -927,7 +1028,7 @@ header a:hover {
 
 .door-attach-browser-path {
   font-size: 0.8rem;
-  color: #94a3b8;
+  color: #475569;
 }
 
 .door-attach-browser-controls {
@@ -936,34 +1037,42 @@ header a:hover {
 }
 
 .door-attach-browser-controls button {
-  border: none;
+  border: 1px solid #dbeafe;
   border-radius: 0.6rem;
   padding: 0.4rem 0.75rem;
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
+  background: #eef2ff;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-attach-browser-controls button:hover,
 .door-attach-browser-controls button:focus {
-  background: rgba(56, 189, 248, 0.35);
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 6px 16px rgba(147, 197, 253, 0.3);
+  transform: translateY(-1px);
   outline: none;
 }
 
 .door-attach-browser-choose {
-  border: none;
+  border: 1px solid #dbeafe;
   border-radius: 0.6rem;
   padding: 0.35rem 0.7rem;
-  background: rgba(56, 189, 248, 0.2);
-  color: #38bdf8;
+  background: #eef2ff;
+  color: #1d4ed8;
   font-weight: 600;
   cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .door-attach-browser-choose:hover,
 .door-attach-browser-choose:focus {
-  background: rgba(56, 189, 248, 0.35);
+  background: #dbeafe;
+  border-color: #93c5fd;
+  box-shadow: 0 6px 16px rgba(147, 197, 253, 0.3);
+  transform: translateY(-1px);
   outline: none;
 }
 
@@ -983,10 +1092,11 @@ header a:hover {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
   border-radius: 0.6rem;
   padding: 0.45rem 0.6rem;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
 }
 
 .door-attach-browser-list button {
@@ -1000,5 +1110,317 @@ header a:hover {
 
 .door-attach-browser-empty {
   font-size: 0.75rem;
+  color: #64748b;
+}
+
+.door-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.7rem 1.1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.door-button:focus-visible {
+  outline: 2px solid rgba(37, 99, 235, 0.4);
+  outline-offset: 2px;
+}
+
+.door-button-primary {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.door-button-primary:hover,
+.door-button-primary:focus {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.door-button-secondary {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #2563eb;
+}
+
+.door-button-secondary:hover,
+.door-button-secondary:focus {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1e3a8a;
+  transform: translateY(-1px);
+}
+
+.door-button-danger {
+  background: #fee2e2;
+  border: 1px solid #fecaca;
+  color: #b91c1c;
+}
+
+.door-button-danger:hover,
+.door-button-danger:focus {
+  background: #fecaca;
+  border-color: #fca5a5;
+  transform: translateY(-1px);
+}
+
+.door-links-block {
+  gap: 1rem;
+}
+
+.door-links-title {
+  color: #64748b;
+  letter-spacing: 0.08em;
+}
+
+.door-links {
+  gap: 0.75rem;
+}
+
+.door-link-row {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  color: #1f2937;
+  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
+}
+
+.door-link-title {
+  color: #1f2937;
+}
+
+.door-link-kind,
+.door-link-target {
+  color: #64748b;
+}
+
+.door-link-btn {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #2563eb;
+}
+
+.door-link-btn:hover,
+.door-link-btn:focus {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.door-link-edit {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.door-link-remove {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.door-link-remove:hover,
+.door-link-remove:focus {
+  background: #fecaca;
+  border-color: #fca5a5;
+}
+
+.door-chip {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  color: #2563eb;
+}
+
+.door-chip:hover,
+.door-chip:focus {
+  background: #dbeafe;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.door-chip-file {
+  background: #fee2e2;
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.door-search {
+  gap: 0.75rem;
+}
+
+.door-search input {
+  border: 1px solid #e2e8f0;
+  background: #ffffff;
+  color: #1f2937;
+  box-shadow: inset 0 1px 2px rgba(148, 163, 184, 0.12);
+}
+
+.door-search input::placeholder {
   color: #94a3b8;
 }
+
+.door-search button {
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: #2563eb;
+  color: #ffffff;
+  font-weight: 600;
+  box-shadow: 0 1px 2px rgba(37, 99, 235, 0.25);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.door-search button:hover,
+.door-search button:focus {
+  background: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.door-search-heading,
+.door-search-empty {
+  color: #64748b;
+}
+
+.door-attach-overlay,
+.door-child-dialog {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.door-child-dialog-content,
+.door-attach-dialog {
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 20px 40px rgba(148, 163, 184, 0.2);
+  color: #1f2937;
+}
+
+.door-child-dialog h2,
+.door-attach-body h2 {
+  color: #1f2937;
+}
+
+.door-child-dialog-form label,
+.door-attach-types span,
+.door-attach-browser-path,
+.door-attach-relations-empty {
+  color: #64748b;
+}
+
+.door-child-dialog-form input,
+.door-attach-type,
+.door-attach-relations-list button,
+.door-attach-structure-preview,
+.door-attach-browser,
+.door-attach-browser-controls button,
+.door-attach-browser-choose {
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #1f2937;
+}
+
+.door-child-dialog-form input:focus,
+.door-attach-type:focus,
+.door-attach-type:hover,
+.door-attach-relations-list button:focus,
+.door-attach-relations-list button:hover,
+.door-attach-browser-controls button:focus,
+.door-attach-browser-controls button:hover,
+.door-attach-browser-choose:focus,
+.door-attach-browser-choose:hover {
+  border-color: #93c5fd;
+  background: #eff6ff;
+  color: #1d4ed8;
+  outline: none;
+}
+
+.door-child-dialog-actions button,
+.door-attach-actions button {
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.1rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.door-child-dialog-cancel,
+.door-attach-cancel {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.door-child-dialog-cancel:hover,
+.door-child-dialog-cancel:focus,
+.door-attach-cancel:hover,
+.door-attach-cancel:focus {
+  background: #cbd5f5;
+  transform: translateY(-1px);
+}
+
+.door-child-dialog-create,
+.door-attach-submit {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+}
+
+.door-child-dialog-create:hover,
+.door-child-dialog-create:focus,
+.door-attach-submit:hover,
+.door-attach-submit:focus {
+  background: #1d4ed8;
+  border-color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+.door-child-dialog-create:disabled,
+.door-attach-submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.door-attach-actions {
+  border-top: 1px solid #e2e8f0;
+}
+
+.door-attach-type.active,
+.door-attach-relations-list button.active {
+  border-color: #2563eb;
+  background: #dbeafe;
+  color: #1d4ed8;
+}
+
+.door-attach-browser {
+  display: none;
+}
+
+.door-attach-browser.active {
+  display: flex;
+}
+
+.door-attach-structure-preview {
+  background: #111827;
+  color: #f8fafc;
+}
+
+@media (min-width: 960px) {
+  .door-layout {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .door-editor-panel {
+    position: sticky;
+    top: 1.5rem;
+    align-self: flex-start;
+  }
+}
+

--- a/CLOUD/cloud.php
+++ b/CLOUD/cloud.php
@@ -655,9 +655,14 @@ function door_handle_create(){
     $parentNode=null;
   }else{
     $parentNode=null;
-    if(!cjsf_find_item_ref($root,$parent,$parentNode)) bad('Parent not found',404);
-    if(!isset($parentNode['children']) || !is_array($parentNode['children'])) $parentNode['children']=[];
-    $list=&$parentNode['children'];
+    if(!cjsf_find_item_ref($root,$parent,$parentNode)){
+      $list=&$root;
+      $parentNode=null;
+      $parent='';
+    }else{
+      if(!isset($parentNode['children']) || !is_array($parentNode['children'])) $parentNode['children']=[];
+      $list=&$parentNode['children'];
+    }
   }
   $ref=null;
   if(!empty($list) && isset($list[0]) && is_array($list[0])) $ref=$list[0];
@@ -865,14 +870,14 @@ function door_render_shell($title){
           <div class="door-links-block">
             <div class="door-links-header">
               <h2 class="door-links-title">Teleport Links</h2>
-              <button type="button" class="door-link-attach" id="door-attach">Attach…</button>
+              <button type="button" class="door-link-attach door-button door-button-secondary px-3 py-2 text-sm font-medium" id="door-attach">Attach…</button>
             </div>
             <ul class="door-links" id="door-links-list"></ul>
           </div>
           <div class="door-editor-actions">
-            <button type="button" class="door-save" id="door-save">Save changes</button>
-            <button type="button" class="door-new" id="door-add-child">Add room</button>
-            <button type="button" class="door-delete" id="door-delete">Delete room</button>
+            <button type="button" class="door-button door-button-primary px-3 py-2 text-sm font-semibold shadow-sm" id="door-save">Save changes</button>
+            <button type="button" class="door-button door-button-secondary px-3 py-2 text-sm font-semibold" id="door-add-child">Add room</button>
+            <button type="button" class="door-button door-button-danger px-3 py-2 text-sm font-semibold" id="door-delete">Delete room</button>
           </div>
         </div>
       </section>
@@ -887,8 +892,8 @@ function door_render_shell($title){
             <input id="door-child-name" name="title" value="New Room" placeholder="New Room" autocomplete="off" required>
           </label>
           <div class="door-child-dialog-actions">
-            <button type="button" class="door-child-dialog-cancel" id="door-child-cancel">Cancel</button>
-            <button type="submit" class="door-child-dialog-create" id="door-child-create">Create</button>
+            <button type="button" class="door-button door-button-secondary px-3 py-2 text-sm font-medium door-child-dialog-cancel" id="door-child-cancel">Cancel</button>
+            <button type="submit" class="door-button door-button-primary px-3 py-2 text-sm font-semibold door-child-dialog-create" id="door-child-create">Create</button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary
- restyle the Door interface with Cloud’s light surfaces, blue accents, and softened tiles and panels
- refresh form fields, link chips, dialogs, and buttons to use the shared button utilities and accessible focus states
- fall back to the root collection when a child room request references a missing parent id to prevent hard errors

## Testing
- php -l CLOUD/cloud.php

------
https://chatgpt.com/codex/tasks/task_e_68e0d07d2bd8832cb732c024bb25da94