### PR TITLE
Refine Door shell preview integration

### DIFF
--- a/CLOUD/assets/css/door.css
+++ b/CLOUD/assets/css/door.css
@@ -1,8 +1,46 @@
+:root {
+  --door-font-sans: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --door-font-mono: "JetBrains Mono", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --door-color-bg: #f8fafc;
+  --door-color-surface: #ffffff;
+  --door-color-surface-muted: #f1f5f9;
+  --door-color-border: #dbe4f4;
+  --door-color-border-strong: #cbd5f5;
+  --door-color-text: #0f172a;
+  --door-color-text-muted: #475569;
+  --door-color-text-subtle: #64748b;
+  --door-color-accent: #2563eb;
+  --door-color-accent-strong: #1d4ed8;
+  --door-color-accent-soft: #dbeafe;
+  --door-color-accent-soft-alt: #eef2ff;
+  --door-color-success: #166534;
+  --door-color-success-soft: #dcfce7;
+  --door-color-danger: #b91c1c;
+  --door-color-danger-soft: #fee2e2;
+  --door-radius-sm: 0.5rem;
+  --door-radius-md: 0.75rem;
+  --door-radius-lg: 1rem;
+  --door-radius-pill: 999px;
+  --door-shadow-xs: 0 2px 8px rgba(15, 23, 42, 0.08);
+  --door-shadow-sm: 0 6px 18px rgba(15, 23, 42, 0.12);
+  --door-shadow-md: 0 16px 32px rgba(15, 23, 42, 0.14);
+  --door-shadow-lg: 0 24px 48px rgba(15, 23, 42, 0.18);
+  --door-focus-ring: 0 0 0 3px rgba(37, 99, 235, 0.35);
+  --door-transition: 0.2s ease;
+  --door-grid-min: 11rem;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f8fafc;
-  color: #0f172a;
+  font-family: var(--door-font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  background: var(--door-color-bg);
+  color: var(--door-color-text);
   min-height: 100vh;
   display: flex;
   flex-direction: column;
@@ -10,150 +48,228 @@ body {
 
 a {
   color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+button, input, textarea, select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  transition: var(--door-transition);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: none;
+  box-shadow: var(--door-focus-ring);
+}
+
+.hidden {
+  display: none !important;
+}
+
+.bg-gray-200 {
+  background: var(--door-color-accent-soft);
+  color: var(--door-color-accent);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 header {
-  padding: 1rem;
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.06);
+  padding: 1rem 1.5rem;
+  background: var(--door-color-surface);
+  border-bottom: 1px solid var(--door-color-border);
+  box-shadow: var(--door-shadow-xs);
+  position: relative;
+  z-index: 5;
 }
 
 header h1 {
-  font-size: 1.5rem;
-  margin: 0;
   flex: 1;
+  margin: 0;
+  font-size: 1.5rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #0f172a;
+  color: var(--door-color-text);
 }
 
 header a {
-  color: #1d4ed8;
-  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent-soft);
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
   font-weight: 600;
-  border: 1px solid #c7d2fe;
-  border-radius: 999px;
-  padding: 0.5rem 1rem;
-  background: #eef2ff;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  text-decoration: none;
+  transition: var(--door-transition);
 }
 
 header a:hover,
 header a:focus-visible {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
-  outline: none;
+  background: var(--door-color-accent-soft);
+  border-color: var(--door-color-accent);
+  box-shadow: var(--door-focus-ring);
 }
 
 .door-shell {
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.5rem;
   padding: 1.5rem;
   width: min(1200px, 100%);
-  margin: 0 auto;
+  margin: 0 auto 3rem;
+}
+
+.door-status {
+  min-height: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--door-color-text-muted);
+}
+
+.door-status.error {
+  color: var(--door-color-danger);
+}
+
+.door-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(280px, 1.4fr);
+  gap: 1.5rem;
+  align-items: start;
 }
 
 .door-panel {
-  background: #ffffff;
-  border-radius: 1rem;
+  background: var(--door-color-surface);
+  border-radius: var(--door-radius-lg);
+  border: 1px solid var(--door-color-border);
+  box-shadow: var(--door-shadow-sm);
   padding: 1.25rem;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-editor-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.door-grid-wrap {
+  padding: 1.25rem;
 }
 
 .door-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--door-grid-min), 1fr));
   gap: 1rem;
-  width: 100%;
 }
 
 .door-tile-wrap {
   position: relative;
+  display: flex;
 }
 
-
 .door-tile {
-  aspect-ratio: 1 / 1;
-  background: linear-gradient(135deg, #eef2ff, #dbeafe);
+  flex: 1;
+  min-height: 8rem;
+  border-radius: var(--door-radius-lg);
   border: 2px solid transparent;
-  border-radius: 1rem;
-  color: #0f172a;
-  font-size: 1.05rem;
+  background: linear-gradient(135deg, var(--door-color-accent-soft-alt), var(--door-color-accent-soft));
+  color: var(--door-color-text);
   font-weight: 600;
+  padding: 1rem;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  padding: 0.75rem;
-  box-shadow: 0 12px 25px rgba(148, 163, 184, 0.22);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: var(--door-shadow-sm);
+  transition: var(--door-transition);
   touch-action: manipulation;
 }
 
-.door-tile:focus,
-.door-tile:hover {
+.door-tile:hover,
+.door-tile:focus-visible {
   transform: translateY(-4px);
-  border-color: #2563eb;
-  box-shadow: 0 16px 35px rgba(37, 99, 235, 0.25);
-  outline: none;
+  border-color: var(--door-color-accent);
+  box-shadow: var(--door-shadow-md);
+}
+
+.door-tile.door-add {
+  background: linear-gradient(135deg, var(--door-color-success-soft), #bae6fd);
+  color: var(--door-color-accent);
+  font-size: 2rem;
+}
+
+.door-tile.door-search {
+  background: linear-gradient(135deg, var(--door-color-accent), var(--door-color-accent-strong));
+  color: #f8fafc;
 }
 
 .door-tile-action {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
+  top: 0.6rem;
+  right: 0.6rem;
   border: none;
-  border-radius: 999px;
-  padding: 0.25rem 0.6rem;
-  font-size: 0.7rem;
+  border-radius: var(--door-radius-pill);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
   text-transform: uppercase;
-  background: rgba(37, 99, 235, 0.15);
-  color: #1d4ed8;
-  cursor: pointer;
-  transition: background 0.2s, transform 0.2s;
-}
-
-.door-tile-action.door-tile-more {
-  font-size: 0.65rem;
-  letter-spacing: 0.08em;
-  min-width: 3.5rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  letter-spacing: 0.05em;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--door-color-accent-strong);
 }
 
 .door-tile-action:hover,
-.door-tile-action:focus {
-  background: rgba(59, 130, 246, 0.25);
-  outline: none;
-  transform: translateY(-1px);
+.door-tile-action:focus-visible {
+  background: rgba(37, 99, 235, 0.2);
+  box-shadow: var(--door-focus-ring);
 }
 
 .door-tile-menu {
   position: absolute;
-  top: 2.6rem;
+  top: 3.25rem;
   right: 0.5rem;
-  min-width: 9rem;
-  background: #ffffff;
-  border-radius: 0.75rem;
-  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.12);
-  border: 1px solid #e2e8f0;
+  min-width: 10rem;
+  background: var(--door-color-surface);
+  border: 1px solid var(--door-color-border-strong);
+  border-radius: var(--door-radius-md);
+  box-shadow: var(--door-shadow-md);
   padding: 0.35rem 0;
   display: none;
   flex-direction: column;
-  z-index: 25;
+  z-index: 20;
 }
 
 .door-tile-menu.active {
@@ -161,38 +277,18 @@ header a:focus-visible {
 }
 
 .door-tile-menu-item {
-  background: none;
   border: none;
-  padding: 0.45rem 0.95rem;
-  font-size: 0.85rem;
-  color: #1f2937;
+  background: transparent;
+  padding: 0.5rem 1rem;
   text-align: left;
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  font-size: 0.9rem;
+  color: var(--door-color-text);
 }
 
 .door-tile-menu-item:hover,
-.door-tile-menu-item:focus {
-  background: #eff6ff;
-  color: #1d4ed8;
-  outline: none;
-}
-
-.door-tile.door-add {
-  background: linear-gradient(135deg, #e0f2fe, #bfdbfe);
-  color: #1d4ed8;
-  font-size: 2rem;
-}
-
-.door-tile.door-search {
-  background: linear-gradient(135deg, #2563eb, #1d4ed8);
-  color: #f8fafc;
-}
-
-.door-tile.door-search span {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
+.door-tile-menu-item:focus-visible {
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
 }
 
 .door-breadcrumb {
@@ -201,82 +297,71 @@ header a:focus-visible {
   gap: 0.75rem;
   align-items: center;
   font-size: 0.95rem;
+  color: var(--door-color-text-muted);
 }
 
 .door-crumb {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.4rem;
 }
 
 .door-breadcrumb button {
-  background: none;
   border: none;
-  color: #1d4ed8;
+  background: transparent;
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--door-radius-pill);
+  color: var(--door-color-accent-strong);
   font-weight: 600;
-  cursor: pointer;
-  padding: 0.25rem 0.6rem;
-  border-radius: 0.5rem;
 }
 
 .door-breadcrumb button:hover,
-.door-breadcrumb button:focus {
-  background: #e0f2fe;
-  outline: none;
+.door-breadcrumb button:focus-visible {
+  background: var(--door-color-accent-soft);
 }
 
 .door-crumb-classic {
   border: none;
-  border-radius: 0.5rem;
-  background: #e0f2fe;
+  border-radius: var(--door-radius-pill);
+  padding: 0.25rem 0.65rem;
+  background: var(--door-color-accent-soft);
   color: #0369a1;
-  cursor: pointer;
-  padding: 0.2rem 0.55rem;
-  font-size: 0.7rem;
-  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  transition: background 0.2s, color 0.2s;
 }
 
 .door-crumb-classic:hover,
-.door-crumb-classic:focus {
-  background: #bae6fd;
-  color: #0f172a;
-  outline: none;
+.door-crumb-classic:focus-visible {
+  background: var(--door-color-accent-strong);
+  color: #f8fafc;
 }
 
 .door-rail {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .door-node-link {
-  background: none;
   border: none;
-  color: #1d4ed8;
+  background: transparent;
+  padding: 0.4rem 0.75rem;
+  border-radius: var(--door-radius-pill);
+  color: var(--door-color-accent-strong);
   font-weight: 600;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.4rem;
-  font-size: 0.9rem;
-  text-align: left;
-  touch-action: manipulation;
+  min-height: 2.5rem;
 }
 
-.door-node-link:hover {
-  background: #e0f2fe;
-}
-
-.door-node-link:focus {
-  outline: 2px solid rgba(59, 130, 246, 0.35);
-  outline-offset: 2px;
+.door-node-link:hover,
+.door-node-link:focus-visible {
+  background: var(--door-color-accent-soft);
 }
 
 .door-search-panel {
   display: none;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .door-search-panel.active {
@@ -285,45 +370,35 @@ header a:focus-visible {
 
 .door-search {
   display: flex;
-  gap: 0.5rem;
   flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
 .door-search input {
-  flex: 1;
-  min-width: 200px;
-  padding: 0.6rem 0.8rem;
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
-  color: #0f172a;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.door-search input:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  flex: 1 1 220px;
+  min-height: 2.75rem;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border-strong);
+  background: var(--door-color-surface);
+  color: var(--door-color-text);
 }
 
 .door-search button {
-  padding: 0.6rem 1rem;
-  border-radius: 0.75rem;
+  min-height: 2.75rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: var(--door-radius-md);
   border: none;
-  background: #2563eb;
+  background: var(--door-color-accent);
   color: #f8fafc;
   font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 8px 18px rgba(37, 99, 235, 0.25);
-  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+  box-shadow: var(--door-shadow-sm);
 }
 
 .door-search button:hover,
 .door-search button:focus-visible {
-  background: #1d4ed8;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.3);
-  transform: translateY(-1px);
-  outline: none;
+  background: var(--door-color-accent-strong);
+  box-shadow: var(--door-shadow-md);
 }
 
 .door-chip {
@@ -331,31 +406,26 @@ header a:focus-visible {
   align-items: center;
   justify-content: center;
   gap: 0.35rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 9999px;
-  border: 1px solid #cbd5f5;
-  background: #eef2ff;
-  color: #1d4ed8;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent-soft);
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
   font-weight: 600;
   font-size: 0.85rem;
-  cursor: pointer;
-  text-decoration: none;
-  transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
   touch-action: manipulation;
 }
 
 .door-chip:hover,
-.door-chip:focus {
-  border-color: #93c5fd;
-  background: #dbeafe;
-  transform: translateY(-1px);
-  outline: none;
+.door-chip:focus-visible {
+  border-color: var(--door-color-accent);
+  background: var(--door-color-accent-soft);
 }
 
 .door-chip-file {
   border-color: #fecaca;
   background: #fee2e2;
-  color: #b91c1c;
+  color: var(--door-color-danger);
 }
 
 .door-search-quick {
@@ -367,14 +437,14 @@ header a:focus-visible {
 .door-search-section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .door-search-heading {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: #64748b;
+  color: var(--door-color-text-subtle);
 }
 
 .door-search-chips {
@@ -385,44 +455,34 @@ header a:focus-visible {
 
 .door-search-empty {
   font-size: 0.85rem;
-  color: #64748b;
-}
-
-.door-status {
-  min-height: 1.5rem;
-  font-size: 0.9rem;
-  color: #0f172a;
-}
-
-.door-status.error {
-  color: #f87171;
+  color: var(--door-color-text-subtle);
 }
 
 .door-editor {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .door-editor label {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  font-size: 0.85rem;
-  color: #475569;
-  text-transform: uppercase;
+  gap: 0.4rem;
+  font-size: 0.8rem;
   letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--door-color-text-subtle);
 }
 
 .door-editor input,
 .door-editor textarea {
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
-  color: #0f172a;
-  padding: 0.6rem 0.75rem;
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border-strong);
+  background: var(--door-color-surface);
+  color: var(--door-color-text);
+  padding: 0.7rem 0.85rem;
   font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  transition: var(--door-transition);
 }
 
 .door-editor textarea {
@@ -430,98 +490,73 @@ header a:focus-visible {
   resize: vertical;
 }
 
-.door-editor input:focus,
-.door-editor textarea:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+.door-editor input:focus-visible,
+.door-editor textarea:focus-visible {
+  border-color: var(--door-color-accent);
+}
+
+.door-button {
+  min-height: 2.75rem;
+  border-radius: var(--door-radius-md);
+  border: 1px solid transparent;
+  padding: 0.65rem 1rem;
+  font-weight: 600;
+  touch-action: manipulation;
+  transition: var(--door-transition);
+}
+
+.door-button-primary {
+  background: var(--door-color-accent);
+  border-color: var(--door-color-accent);
+  color: #f8fafc;
+  box-shadow: var(--door-shadow-sm);
+}
+
+.door-button-primary:hover,
+.door-button-primary:focus-visible {
+  background: var(--door-color-accent-strong);
+  border-color: var(--door-color-accent-strong);
+  box-shadow: var(--door-shadow-md);
+}
+
+.door-button-secondary {
+  background: var(--door-color-accent-soft-alt);
+  border-color: var(--door-color-accent-soft);
+  color: var(--door-color-accent-strong);
+}
+
+.door-button-secondary:hover,
+.door-button-secondary:focus-visible {
+  background: var(--door-color-accent-soft);
+  border-color: var(--door-color-accent);
+}
+
+.door-button-danger {
+  background: var(--door-color-danger-soft);
+  border-color: #fecaca;
+  color: var(--door-color-danger);
+}
+
+.door-button-danger:hover,
+.door-button-danger:focus-visible {
+  background: var(--door-color-danger);
+  color: #fef2f2;
 }
 
 .door-editor-actions {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.door-editor-actions button {
-  flex: 1 1 120px;
-  padding: 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid #dbeafe;
-  font-weight: 600;
-  cursor: pointer;
-  touch-action: manipulation;
-  background: #eef2ff;
-  color: #1d4ed8;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-save {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #f8fafc;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
-}
-
-.door-new {
-  background: #dcfce7;
-  border-color: #bbf7d0;
-  color: #166534;
-}
-
-.door-delete {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
-}
-
-.door-editor-actions button:hover,
-.door-editor-actions button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 24px rgba(148, 163, 184, 0.2);
-  outline: none;
+.door-editor-actions .door-button {
+  flex: 1 1 140px;
 }
 
 .door-links-block {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-}
-
-.door-links-header {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  justify-content: space-between;
-}
-
-.door-links-title {
-  margin: 0;
-  font-size: 0.9rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: #475569;
-}
-
-.door-link-attach {
-  border: 1px solid #dbeafe;
-  padding: 0.5rem 0.85rem;
-  border-radius: 0.75rem;
-  background: #eef2ff;
-  color: #1d4ed8;
-  font-weight: 600;
-  cursor: pointer;
-  touch-action: manipulation;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-link-attach:hover,
-.door-link-attach:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.35);
-  transform: translateY(-1px);
-  outline: none;
+  gap: 1rem;
 }
 
 .door-links {
@@ -530,150 +565,86 @@ header a:focus-visible {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
 .door-links li {
   display: flex;
-  align-items: center;
+  flex-direction: column;
   gap: 0.5rem;
-  background: #f8fafc;
-  border-radius: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.06);
+  padding: 0.85rem;
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border);
+  background: var(--door-color-surface-muted);
 }
 
 .door-link-meta {
   display: flex;
-  flex-direction: column;
-  font-size: 0.75rem;
-  color: #64748b;
-}
-
-.door-link-meta span {
-  line-height: 1.2;
+  gap: 0.75rem;
+  font-size: 0.8rem;
+  color: var(--door-color-text-subtle);
 }
 
 .door-link-actions {
-  margin-left: auto;
-  display: inline-flex;
-  gap: 0.4rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .door-link-classic,
 .door-link-edit,
 .door-link-remove {
-  border: 1px solid transparent;
-  padding: 0.4rem 0.75rem;
-  border-radius: 0.75rem;
-  cursor: pointer;
-  font-weight: 600;
-  touch-action: manipulation;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background 0.2s ease;
-}
-
-.door-link-classic {
-  background: #eef2ff;
-  border-color: #dbeafe;
-  color: #1d4ed8;
+  border: none;
+  border-radius: var(--door-radius-pill);
+  padding: 0.35rem 0.8rem;
+  background: var(--door-color-surface);
+  color: var(--door-color-text-muted);
+  font-size: 0.85rem;
 }
 
 .door-link-classic:hover,
-.door-link-classic:focus-visible {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.3);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.door-link-edit {
-  background: #ecfeff;
-  border-color: #bae6fd;
-  color: #0369a1;
-}
-
+.door-link-classic:focus-visible,
 .door-link-edit:hover,
 .door-link-edit:focus-visible {
-  background: #bae6fd;
-  border-color: #7dd3fc;
-  box-shadow: 0 8px 18px rgba(125, 211, 252, 0.3);
-  transform: translateY(-1px);
-  outline: none;
+  background: var(--door-color-accent-soft);
+  color: var(--door-color-accent-strong);
 }
 
 .door-link-remove {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
+  background: var(--door-color-danger-soft);
+  color: var(--door-color-danger);
 }
 
 .door-link-remove:hover,
 .door-link-remove:focus-visible {
-  background: #fecaca;
-  border-color: #fca5a5;
-  box-shadow: 0 8px 18px rgba(248, 113, 113, 0.3);
-  transform: translateY(-1px);
-  outline: none;
+  background: var(--door-color-danger);
+  color: #fef2f2;
 }
 
-.door-layout {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+.door-link-attach {
+  align-self: flex-start;
+  min-height: 2.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent-soft);
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
+  font-weight: 600;
 }
 
-.door-grid-wrap {
-  flex: 2;
-}
-
-.door-editor-panel {
-  flex: 1;
-}
-
-@media (min-width: 960px) {
-  .door-layout {
-    flex-direction: row;
-    align-items: flex-start;
-  }
-
-  .door-editor-panel {
-    position: sticky;
-    top: 1rem;
-  }
-}
-
-.door-attach-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 23, 42, 0.75);
-  backdrop-filter: blur(6px);
-  display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  padding: 1.5rem;
-}
-
-.door-attach-overlay.active {
-  display: flex;
+.door-link-attach:hover,
+.door-link-attach:focus-visible {
+  background: var(--door-color-accent-soft);
+  border-color: var(--door-color-accent);
 }
 
 .door-child-dialog {
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.75);
-  backdrop-filter: blur(4px);
-  display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 1100;
-  padding: 1.5rem;
-}
-
-.door-child-dialog.active {
-  display: flex;
+  display: grid;
+  place-items: center;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 50;
 }
 
 .door-child-dialog[hidden] {
@@ -681,21 +652,15 @@ header a:focus-visible {
 }
 
 .door-child-dialog-content {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 1rem;
+  background: var(--door-color-surface);
+  border-radius: var(--door-radius-lg);
+  border: 1px solid var(--door-color-border);
   width: min(360px, 100%);
   padding: 1.5rem;
-  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
+  box-shadow: var(--door-shadow-lg);
   display: flex;
   flex-direction: column;
   gap: 1rem;
-}
-
-.door-child-dialog h2 {
-  margin: 0;
-  font-size: 1.15rem;
-  color: #0f172a;
 }
 
 .door-child-dialog-form {
@@ -708,79 +673,76 @@ header a:focus-visible {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  color: #475569;
-  font-size: 0.9rem;
+  color: var(--door-color-text-subtle);
 }
 
 .door-child-dialog-form input {
-  border: 1px solid #cbd5f5;
-  border-radius: 0.75rem;
-  background: #ffffff;
-  color: #0f172a;
-  padding: 0.65rem 0.75rem;
-  font-size: 1rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.door-child-dialog-form input:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border-strong);
+  padding: 0.65rem 0.85rem;
 }
 
 .door-child-dialog-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0.5rem;
+  gap: 0.75rem;
 }
 
-.door-child-dialog-actions button {
-  border: 1px solid #dbeafe;
-  border-radius: 0.75rem;
-  padding: 0.65rem 1rem;
+.door-child-dialog-cancel,
+.door-child-dialog-create {
+  border-radius: var(--door-radius-md);
+  min-height: 2.5rem;
+  padding: 0.55rem 1.1rem;
+  border: 1px solid transparent;
   font-weight: 600;
-  cursor: pointer;
-  touch-action: manipulation;
-  background: #eef2ff;
-  color: #1d4ed8;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-child-dialog-actions button:disabled {
-  opacity: 0.6;
-  cursor: progress;
-}
-
-.door-child-dialog-actions button:hover,
-.door-child-dialog-actions button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 22px rgba(148, 163, 184, 0.2);
-  outline: none;
 }
 
 .door-child-dialog-cancel {
-  background: #f1f5f9;
-  border-color: #e2e8f0;
-  color: #475569;
+  background: var(--door-color-surface-muted);
+  border-color: var(--door-color-border);
+  color: var(--door-color-text-muted);
+}
+
+.door-child-dialog-cancel:hover,
+.door-child-dialog-cancel:focus-visible {
+  border-color: var(--door-color-accent);
 }
 
 .door-child-dialog-create {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--door-color-accent);
+  border-color: var(--door-color-accent);
   color: #f8fafc;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.door-child-dialog-create:hover,
+.door-child-dialog-create:focus-visible {
+  background: var(--door-color-accent-strong);
+}
+
+.door-attach-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 55;
+}
+
+.door-attach-overlay.active {
+  display: flex;
 }
 
 .door-attach-dialog {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 1rem;
-  width: min(640px, 100%);
+  background: var(--door-color-surface);
+  border-radius: var(--door-radius-lg);
+  border: 1px solid var(--door-color-border);
+  width: min(680px, 100%);
   max-height: 90vh;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.18);
+  box-shadow: var(--door-shadow-lg);
 }
 
 .door-attach-body {
@@ -788,303 +750,131 @@ header a:focus-visible {
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 1.25rem;
 }
 
-.door-attach-body h2 {
-  margin: 0;
-  font-size: 1.15rem;
+.door-attach-hint {
+  font-size: 0.9rem;
+  color: var(--door-color-text-subtle);
 }
 
 .door-attach-types {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
+  gap: 0.75rem;
 }
 
 .door-attach-type {
-  border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  background: #f8fafc;
-  color: #0f172a;
-  padding: 0.6rem 0.75rem;
-  text-align: left;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.door-attach-type strong {
-  display: block;
-  font-size: 0.95rem;
-}
-
-.door-attach-type span {
-  display: block;
-  font-size: 0.75rem;
-  color: #64748b;
-  margin-top: 0.25rem;
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border);
+  background: var(--door-color-surface-muted);
+  padding: 0.6rem;
+  min-height: 2.75rem;
+  font-weight: 600;
+  color: var(--door-color-text-muted);
 }
 
 .door-attach-type.active {
-  border-color: #93c5fd;
-  background: #dbeafe;
-  box-shadow: 0 10px 24px rgba(147, 197, 253, 0.25);
-}
-
-.door-attach-type:focus-visible,
-.door-attach-type:hover {
-  outline: none;
-  border-color: #2563eb;
-  background: #eff6ff;
-  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.2);
-  transform: translateY(-2px);
-}
-
-.door-attach-field label {
-  display: block;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: #475569;
-  margin-bottom: 0.35rem;
-}
-
-.door-attach-field input,
-.door-attach-field textarea {
-  width: 100%;
-  padding: 0.6rem 0.75rem;
-  border-radius: 0.75rem;
-  border: 1px solid #cbd5f5;
-  background: #ffffff;
-  color: #0f172a;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.door-attach-field input:focus,
-.door-attach-field textarea:focus {
-  outline: none;
-  border-color: #2563eb;
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  border-color: var(--door-color-accent);
+  background: var(--door-color-accent-soft);
+  color: var(--door-color-accent-strong);
 }
 
 .door-attach-pane {
   display: none;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .door-attach-pane.active {
   display: flex;
 }
 
+.door-attach-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.door-attach-field label {
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--door-color-text-subtle);
+}
+
+.door-attach-field input,
+.door-attach-field textarea,
+.door-attach-field select {
+  border-radius: var(--door-radius-md);
+  border: 1px solid var(--door-color-border-strong);
+  padding: 0.6rem 0.8rem;
+  background: var(--door-color-surface);
+}
+
+.door-attach-field textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.door-attach-hint strong {
+  color: var(--door-color-text);
+}
+
 .door-attach-path {
   display: flex;
-  gap: 0.5rem;
-}
-
-.door-attach-path input {
-  flex: 1;
-}
-
-.door-attach-path button {
-  padding: 0.6rem 1rem;
-  border-radius: 0.75rem;
-  border: 1px solid #dbeafe;
-  background: #eef2ff;
-  color: #1d4ed8;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-attach-path button:hover,
-.door-attach-path button:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.3);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.door-attach-hint {
-  font-size: 0.75rem;
-  color: #64748b;
-}
-
-.door-attach-relations {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.door-attach-relations-list {
-  max-height: 200px;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.door-attach-relations-list button {
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #0f172a;
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  text-align: left;
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
-}
-
-.door-attach-relations-list button.active {
-  border-color: #93c5fd;
-  background: #dbeafe;
-  color: #1d4ed8;
-  box-shadow: 0 8px 18px rgba(147, 197, 253, 0.25);
-}
-
-.door-attach-relations-empty {
-  font-size: 0.75rem;
-  color: #64748b;
-}
-
-.door-attach-structure-preview {
-  max-height: 160px;
-  overflow: auto;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  padding: 0.75rem;
-  background: #f8fafc;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
-  font-size: 0.75rem;
-  color: #0f172a;
-  white-space: pre-wrap;
-}
-
-.door-attach-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  padding: 1rem 1.5rem 1.5rem;
-  border-top: 1px solid #e2e8f0;
-}
-
-.door-attach-actions button {
-  padding: 0.6rem 1.1rem;
-  border-radius: 0.75rem;
-  border: 1px solid #dbeafe;
-  font-weight: 600;
-  cursor: pointer;
-  background: #eef2ff;
-  color: #1d4ed8;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-attach-cancel {
-  background: #f1f5f9;
-  border-color: #e2e8f0;
-  color: #475569;
-}
-
-.door-attach-submit {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #f8fafc;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
-}
-
-.door-attach-submit:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.door-attach-actions button:hover,
-.door-attach-actions button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(148, 163, 184, 0.2);
-  outline: none;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .door-attach-browser {
-  border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  background: #f8fafc;
-  padding: 0.75rem;
-  display: none;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.door-attach-browser.active {
+  border: 1px solid var(--door-color-border);
+  border-radius: var(--door-radius-md);
+  overflow: hidden;
   display: flex;
+  flex-direction: column;
+  background: var(--door-color-surface-muted);
 }
 
 .door-attach-browser-header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--door-color-surface);
+  border-bottom: 1px solid var(--door-color-border);
+}
+
+.door-attach-browser-path {
+  font-size: 0.85rem;
+  color: var(--door-color-text-muted);
+}
+
+.door-attach-browser-controls {
+  display: flex;
   align-items: center;
   gap: 0.5rem;
 }
 
-.door-attach-browser-path {
-  font-size: 0.8rem;
-  color: #475569;
-}
-
-.door-attach-browser-controls {
-  display: inline-flex;
-  gap: 0.4rem;
-}
-
 .door-attach-browser-controls button {
-  border: 1px solid #dbeafe;
-  border-radius: 0.6rem;
-  padding: 0.4rem 0.75rem;
-  background: #eef2ff;
-  color: #1d4ed8;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-attach-browser-controls button:hover,
-.door-attach-browser-controls button:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  box-shadow: 0 6px 16px rgba(147, 197, 253, 0.3);
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.door-attach-browser-choose {
-  border: 1px solid #dbeafe;
-  border-radius: 0.6rem;
-  padding: 0.35rem 0.7rem;
-  background: #eef2ff;
-  color: #1d4ed8;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
-}
-
-.door-attach-browser-choose:hover,
-.door-attach-browser-choose:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  box-shadow: 0 6px 16px rgba(147, 197, 253, 0.3);
-  transform: translateY(-1px);
-  outline: none;
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-border);
+  background: var(--door-color-surface);
+  padding: 0.35rem 0.75rem;
+  min-height: 2.2rem;
 }
 
 .door-attach-browser-list {
   list-style: none;
   margin: 0;
-  padding: 0;
-  max-height: 220px;
+  padding: 0.75rem 1rem;
+  max-height: 200px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.5rem;
 }
 
 .door-attach-browser-list li {
@@ -1092,709 +882,333 @@ header a:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
 }
 
 .door-attach-browser-list button {
   border: none;
-  background: none;
-  color: inherit;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
+  background: transparent;
+  padding: 0.4rem 0.6rem;
+  border-radius: var(--door-radius-md);
+  color: var(--door-color-text);
+  min-height: 2.2rem;
+}
+
+.door-attach-browser-list button:hover,
+.door-attach-browser-list button:focus-visible {
+  background: var(--door-color-accent-soft);
+}
+
+.door-attach-browser-choose {
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent-soft);
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
 }
 
 .door-attach-browser-empty {
-  font-size: 0.75rem;
-  color: #64748b;
-}
-
-.door-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.7rem 1.1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.door-button:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.4);
-  outline-offset: 2px;
-}
-
-.door-button-primary {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #ffffff;
-}
-
-.door-button-primary:hover,
-.door-button-primary:focus {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.door-button-secondary {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-button-secondary:hover,
-.door-button-secondary:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1e3a8a;
-  transform: translateY(-1px);
-}
-
-.door-button-danger {
-  background: #fee2e2;
-  border: 1px solid #fecaca;
-  color: #b91c1c;
-}
-
-.door-button-danger:hover,
-.door-button-danger:focus {
-  background: #fecaca;
-  border-color: #fca5a5;
-  transform: translateY(-1px);
-}
-
-.door-links-block {
-  gap: 1rem;
-}
-
-.door-links-title {
-  color: #64748b;
-  letter-spacing: 0.08em;
-}
-
-.door-links {
-  gap: 0.75rem;
-}
-
-.door-link-row {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  color: #1f2937;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-}
-
-.door-link-title {
-  color: #1f2937;
-}
-
-.door-link-kind,
-.door-link-target {
-  color: #64748b;
-}
-
-.door-link-btn {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-link-btn:hover,
-.door-link-btn:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-link-edit {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-link-remove {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
-}
-
-.door-link-remove:hover,
-.door-link-remove:focus {
-  background: #fecaca;
-  border-color: #fca5a5;
-}
-
-.door-chip {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-chip:hover,
-.door-chip:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-chip-file {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
-}
-
-.door-search {
-  gap: 0.75rem;
-}
-
-.door-search input {
-  border: 1px solid #e2e8f0;
-  background: #ffffff;
-  color: #1f2937;
-  box-shadow: inset 0 1px 2px rgba(148, 163, 184, 0.12);
-}
-
-.door-search input::placeholder {
-  color: #94a3b8;
-}
-
-/* ===== Light Cloud palette overrides ===== */
-body {
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: #f8fafc;
-  color: #1f2937;
-  line-height: 1.6;
-}
-
-header {
-  padding: 1rem 1.5rem;
-  gap: 1rem;
-  background: #ffffff;
-  border-bottom: 1px solid #e2e8f0;
-  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-}
-
-header h1 {
-  color: #1d4ed8;
-  letter-spacing: 0.12em;
-}
-
-header a {
-  color: #1d4ed8;
-  font-weight: 600;
-  padding: 0.45rem 0.75rem;
-  border-radius: 0.5rem;
-  transition: background 0.2s ease, color 0.2s ease;
-}
-
-header a:hover,
-header a:focus {
-  background: #eff6ff;
-  color: #1e40af;
-  outline: none;
-}
-
-.door-shell {
-  gap: 1.5rem;
-  padding: 1.5rem;
-}
-
-.door-panel {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 1rem;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-  padding: 1.25rem;
-}
-
-.door-layout {
-  gap: 1.5rem;
-}
-
-.door-grid {
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 1.25rem;
-}
-
-.door-tile {
-  background: linear-gradient(135deg, #f1f5f9, #eef2ff);
-  border: 1px solid #e2e8f0;
-  border-radius: 0.9rem;
-  color: #1f2937;
-  padding: 0.85rem;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.door-tile:hover,
-.door-tile:focus {
-  border-color: #bfdbfe;
-  background: linear-gradient(135deg, #eff6ff, #dbeafe);
-  box-shadow: 0 12px 28px rgba(148, 163, 184, 0.24);
-  outline: none;
-}
-
-.door-tile.door-add {
-  background: #eff6ff;
-  border-color: #bfdbfe;
-  color: #2563eb;
-}
-
-.door-tile.door-search {
-  background: linear-gradient(135deg, #3b82f6, #2563eb);
-  border-color: transparent;
-  color: #ffffff;
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.3);
-}
-
-.door-tile-action {
-  top: 0.6rem;
-  right: 0.6rem;
-  padding: 0.3rem 0.7rem;
-  letter-spacing: 0.08em;
-  background: #eff6ff;
-  color: #1d4ed8;
-  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.door-tile-action:hover,
-.door-tile-action:focus {
-  background: #dbeafe;
-  color: #1e3a8a;
-  transform: translateY(-1px);
-  outline: none;
-}
-
-.door-tile-menu {
-  top: 2.8rem;
-  right: 0.6rem;
-  min-width: 10rem;
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  border-radius: 0.75rem;
-  box-shadow: 0 10px 30px rgba(148, 163, 184, 0.25);
-}
-
-.door-tile-menu-item {
-  padding: 0.55rem 1rem;
-  font-size: 0.85rem;
-  color: #1f2937;
-}
-
-.door-tile-menu-item:hover,
-.door-tile-menu-item:focus {
-  background: #eff6ff;
-  color: #1d4ed8;
-}
-
-.door-breadcrumb {
-  color: #475569;
-  gap: 0.75rem;
-}
-
-.door-breadcrumb button {
-  color: #2563eb;
-  padding: 0.35rem 0.7rem;
-  border-radius: 0.5rem;
-}
-
-.door-breadcrumb button:hover,
-.door-breadcrumb button:focus {
-  background: #eff6ff;
-  color: #1d4ed8;
-  outline: none;
-}
-
-.door-crumb-classic {
-  border: 1px solid #bfdbfe;
-  background: #eff6ff;
-  color: #2563eb;
-  letter-spacing: 0.08em;
-}
-
-.door-crumb-classic:hover,
-.door-crumb-classic:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1e40af;
-}
-
-.door-node-link {
-  color: #2563eb;
-  padding: 0.35rem 0.65rem;
-  border-radius: 0.5rem;
-}
-
-.door-node-link:hover,
-.door-node-link:focus {
-  background: #eff6ff;
-  color: #1d4ed8;
-  outline: none;
-}
-
-.door-status {
-  color: #2563eb;
-}
-
-.door-status.error {
-  color: #ef4444;
-}
-
-.door-editor {
-  gap: 1.1rem;
-}
-
-.door-editor label {
-  font-size: 0.8rem;
-  color: #64748b;
-}
-
-.door-editor input,
-.door-editor textarea {
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #1f2937;
-  padding: 0.7rem 0.85rem;
-  border-radius: 0.75rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.door-editor input:focus,
-.door-editor textarea:focus {
-  border-color: #93c5fd;
-  box-shadow: 0 0 0 3px rgba(147, 197, 253, 0.45);
-  outline: none;
-}
-
-.door-editor textarea {
-  min-height: 140px;
-}
-
-.door-editor-actions {
-  gap: 0.75rem;
-}
-
-.door-editor-actions button {
-  flex: 1 1 140px;
-}
-
-.door-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.7rem 1.1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  font-weight: 600;
-  font-size: 0.95rem;
-  cursor: pointer;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
-}
-
-.door-button:focus-visible {
-  outline: 2px solid rgba(37, 99, 235, 0.4);
-  outline-offset: 2px;
-}
-
-.door-button-primary {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #ffffff;
-}
-
-.door-button-primary:hover,
-.door-button-primary:focus {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.door-button-secondary {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-button-secondary:hover,
-.door-button-secondary:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1e3a8a;
-  transform: translateY(-1px);
-}
-
-.door-button-danger {
-  background: #fee2e2;
-  border: 1px solid #fecaca;
-  color: #b91c1c;
-}
-
-.door-button-danger:hover,
-.door-button-danger:focus {
-  background: #fecaca;
-  border-color: #fca5a5;
-  transform: translateY(-1px);
-}
-
-.door-links-block {
-  gap: 1rem;
-}
-
-.door-links-title {
-  color: #64748b;
-  letter-spacing: 0.08em;
-}
-
-.door-links {
-  gap: 0.75rem;
-}
-
-.door-link-row {
-  background: #f8fafc;
-  border: 1px solid #e2e8f0;
-  color: #1f2937;
-  box-shadow: 0 1px 2px rgba(148, 163, 184, 0.18);
-}
-
-.door-link-title {
-  color: #1f2937;
-}
-
-.door-link-kind,
-.door-link-target {
-  color: #64748b;
-}
-
-.door-link-btn {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-link-btn:hover,
-.door-link-btn:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-link-edit {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-link-remove {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
-}
-
-.door-link-remove:hover,
-.door-link-remove:focus {
-  background: #fecaca;
-  border-color: #fca5a5;
-}
-
-.door-chip {
-  background: #eff6ff;
-  border: 1px solid #bfdbfe;
-  color: #2563eb;
-}
-
-.door-chip:hover,
-.door-chip:focus {
-  background: #dbeafe;
-  border-color: #93c5fd;
-  color: #1d4ed8;
-}
-
-.door-chip-file {
-  background: #fee2e2;
-  border-color: #fecaca;
-  color: #b91c1c;
-}
-
-.door-search {
-  gap: 0.75rem;
-}
-
-.door-search input {
-  border: 1px solid #e2e8f0;
-  background: #ffffff;
-  color: #1f2937;
-  box-shadow: inset 0 1px 2px rgba(148, 163, 184, 0.12);
-}
-
-.door-search input::placeholder {
-  color: #94a3b8;
-}
-
-.door-search button {
-  padding: 0.6rem 1.1rem;
-  border-radius: 0.75rem;
-  border: 1px solid transparent;
-  background: #2563eb;
-  color: #ffffff;
-  font-weight: 600;
-  box-shadow: 0 1px 2px rgba(37, 99, 235, 0.25);
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.door-search button:hover,
-.door-search button:focus {
-  background: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.door-search-heading,
-.door-search-empty {
-  color: #64748b;
-}
-
-.door-attach-overlay,
-.door-child-dialog {
-  background: rgba(15, 23, 42, 0.45);
-}
-
-.door-child-dialog-content,
-.door-attach-dialog {
-  background: #ffffff;
-  border: 1px solid #e2e8f0;
-  box-shadow: 0 20px 40px rgba(148, 163, 184, 0.2);
-  color: #1f2937;
-}
-
-.door-child-dialog h2,
-.door-attach-body h2 {
-  color: #1f2937;
-}
-
-.door-child-dialog-form label,
-.door-attach-types span,
-.door-attach-browser-path,
-.door-attach-relations-empty {
-  color: #64748b;
-}
-
-.door-child-dialog-form input,
-.door-attach-type,
-.door-attach-relations-list button,
-.door-attach-structure-preview,
-.door-attach-browser,
-.door-attach-browser-controls button,
-.door-attach-browser-choose {
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #1f2937;
-}
-
-.door-child-dialog-form input:focus,
-.door-attach-type:focus,
-.door-attach-type:hover,
-.door-attach-relations-list button:focus,
-.door-attach-relations-list button:hover,
-.door-attach-browser-controls button:focus,
-.door-attach-browser-controls button:hover,
-.door-attach-browser-choose:focus,
-.door-attach-browser-choose:hover {
-  border-color: #93c5fd;
-  background: #eff6ff;
-  color: #1d4ed8;
-  outline: none;
-}
-
-.door-child-dialog-actions button,
-.door-attach-actions button {
-  border-radius: 0.75rem;
-  padding: 0.65rem 1.1rem;
-  font-weight: 600;
-  border: 1px solid transparent;
-  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
-}
-
-.door-child-dialog-cancel,
-.door-attach-cancel {
-  background: #e2e8f0;
-  color: #475569;
-}
-
-.door-child-dialog-cancel:hover,
-.door-child-dialog-cancel:focus,
-.door-attach-cancel:hover,
-.door-attach-cancel:focus {
-  background: #cbd5f5;
-  transform: translateY(-1px);
-}
-
-.door-child-dialog-create,
-.door-attach-submit {
-  background: #2563eb;
-  border-color: #2563eb;
-  color: #ffffff;
-}
-
-.door-child-dialog-create:hover,
-.door-child-dialog-create:focus,
-.door-attach-submit:hover,
-.door-attach-submit:focus {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.door-child-dialog-create:disabled,
-.door-attach-submit:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-  transform: none;
-}
-
-.door-attach-actions {
-  border-top: 1px solid #e2e8f0;
-}
-
-.door-attach-type.active,
-.door-attach-relations-list button.active {
-  border-color: #2563eb;
-  background: #dbeafe;
-  color: #1d4ed8;
-}
-
-.door-attach-browser {
-  display: none;
-}
-
-.door-attach-browser.active {
-  display: flex;
+  text-align: center;
+  color: var(--door-color-text-subtle);
+  padding: 1rem 0;
 }
 
 .door-attach-structure-preview {
-  background: #111827;
+  border: 1px solid var(--door-color-border-strong);
+  border-radius: var(--door-radius-md);
+  background: var(--door-color-surface);
+  padding: 1rem;
+  min-height: 6rem;
+  font-family: var(--door-font-mono);
+  font-size: 0.85rem;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+.door-attach-relations {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.door-attach-relations-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+  gap: 0.5rem;
+}
+
+.door-attach-relations-list button {
+  border: 1px solid var(--door-color-border);
+  border-radius: var(--door-radius-md);
+  background: var(--door-color-surface);
+  min-height: 2.5rem;
+  padding: 0.35rem 0.6rem;
+  text-align: left;
+}
+
+.door-attach-relations-list button.active {
+  border-color: var(--door-color-accent);
+  background: var(--door-color-accent-soft);
+  color: var(--door-color-accent-strong);
+}
+
+.door-attach-relations-empty {
+  font-size: 0.85rem;
+  color: var(--door-color-text-subtle);
+}
+
+.door-attach-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.75rem;
+}
+
+.door-attach-cancel,
+.door-attach-submit {
+  min-height: 2.6rem;
+  border-radius: var(--door-radius-md);
+  padding: 0.55rem 1.25rem;
+  border: 1px solid transparent;
+  font-weight: 600;
+}
+
+.door-attach-cancel {
+  background: var(--door-color-surface-muted);
+  border-color: var(--door-color-border);
+  color: var(--door-color-text-muted);
+}
+
+.door-attach-submit {
+  background: var(--door-color-accent);
+  border-color: var(--door-color-accent);
   color: #f8fafc;
 }
 
-@media (min-width: 960px) {
+.door-attach-submit:hover,
+.door-attach-submit:focus-visible {
+  background: var(--door-color-accent-strong);
+}
+
+.door-drawer-toggle {
+  margin-left: auto;
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent-soft);
+  background: var(--door-color-surface);
+  color: var(--door-color-accent-strong);
+  padding: 0.4rem 1rem;
+  min-height: 2.5rem;
+}
+
+.door-drawer-toggle:hover,
+.door-drawer-toggle:focus-visible {
+  background: var(--door-color-accent-soft);
+}
+
+.door-drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  opacity: 0;
+  visibility: hidden;
+  transition: var(--door-transition);
+  z-index: 60;
+}
+
+.door-drawer-scrim.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+.door-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(420px, 100%);
+  background: var(--door-color-surface);
+  border-left: 1px solid var(--door-color-border);
+  box-shadow: -12px 0 32px rgba(15, 23, 42, 0.18);
+  transform: translateX(100%);
+  transition: var(--door-transition);
+  z-index: 65;
+  display: flex;
+  flex-direction: column;
+}
+
+.door-drawer.active {
+  transform: translateX(0);
+}
+
+.door-drawer-inner {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-drawer-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 0;
+}
+
+.door-drawer-title {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--door-color-text);
+}
+
+.door-drawer-tabs {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.door-drawer-tab {
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-border);
+  background: var(--door-color-surface-muted);
+  color: var(--door-color-text-muted);
+  min-height: 2.2rem;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+}
+
+.door-drawer-tab:hover,
+.door-drawer-tab:focus-visible,
+.door-drawer-tab.bg-gray-200 {
+  border-color: var(--door-color-accent);
+  background: var(--door-color-accent-soft);
+  color: var(--door-color-accent-strong);
+}
+
+.door-drawer-save {
+  border-radius: var(--door-radius-pill);
+  border: 1px solid var(--door-color-accent);
+  background: var(--door-color-accent);
+  color: #f8fafc;
+  min-height: 2.2rem;
+  padding: 0.35rem 0.9rem;
+  font-weight: 600;
+}
+
+.door-drawer-close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--door-color-text-subtle);
+}
+
+.door-drawer-body {
+  flex: 1;
+  padding: 0 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.door-preview-web {
+  flex: 1;
+  overflow: auto;
+  border: 1px solid var(--door-color-border);
+  border-radius: var(--door-radius-md);
+  padding: 1rem;
+  background: var(--door-color-surface);
+}
+
+.door-preview-raw {
+  flex: 1;
+  border: 1px solid var(--door-color-border);
+  border-radius: var(--door-radius-md);
+  background: var(--door-color-surface);
+  padding: 1rem;
+  font-family: var(--door-font-mono);
+  font-size: 0.85rem;
+  color: var(--door-color-text);
+  resize: none;
+}
+
+.door-drawer-status {
+  margin: 0 1.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--door-radius-md);
+  font-size: 0.85rem;
+  color: var(--door-color-text-subtle);
+  background: transparent;
+  transition: var(--door-transition);
+}
+
+.door-drawer-status.is-info {
+  background: var(--door-color-accent-soft-alt);
+  color: var(--door-color-accent-strong);
+}
+
+.door-drawer-status.is-warn {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.door-drawer-status.is-error {
+  background: var(--door-color-danger-soft);
+  color: var(--door-color-danger);
+}
+
+.door-drawer-status.is-muted {
+  opacity: 0.7;
+}
+
+body.door-drawer-open {
+  overflow: hidden;
+}
+
+@media (max-width: 960px) {
+  header {
+    flex-wrap: wrap;
+  }
+
+  header h1 {
+    flex-basis: 100%;
+  }
+
   .door-layout {
-    flex-direction: row;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
   }
 
   .door-editor-panel {
-    position: sticky;
-    top: 1.5rem;
-    align-self: flex-start;
+    order: -1;
   }
 }
 
+@media (max-width: 640px) {
+  .door-shell {
+    padding: 1rem;
+  }
+
+  .door-panel {
+    padding: 1rem;
+  }
+
+  .door-grid {
+    grid-template-columns: repeat(auto-fill, minmax(9.5rem, 1fr));
+  }
+
+  .door-search {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .door-search button {
+    width: 100%;
+  }
+
+  .door-editor-actions {
+    flex-direction: column;
+  }
+
+  .door-editor-actions .door-button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- load the classic preview service inside Door and expose it through a new drawer with dirty-state toasts and keyboard shortcuts
- normalize room payload handling for updated endpoints, including link labels, node indexes, and RAW save wiring
- restyle the Door workspace with shared tokens, refreshed grid layout, and drawer-focused interactions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0efb0b21c832c89a8cab08aabff46