### PR TITLE
Harden Door builder endpoints and refresh controls

### DIFF
--- a/CLOUD/assets/css/door.css
+++ b/CLOUD/assets/css/door.css
@@ -98,7 +98,7 @@ select:focus-visible {
   border: 0;
 }
 
-header {
+.door-header {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -110,7 +110,7 @@ header {
   z-index: 5;
 }
 
-header h1 {
+.door-header h1 {
   flex: 1;
   margin: 0;
   font-size: 1.5rem;
@@ -119,7 +119,14 @@ header h1 {
   color: var(--door-color-text);
 }
 
-header a {
+.door-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.door-header a,
+.door-header-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -134,11 +141,24 @@ header a {
   transition: var(--door-transition);
 }
 
-header a:hover,
-header a:focus-visible {
+.door-header a:hover,
+.door-header a:focus-visible,
+.door-header-btn:hover,
+.door-header-btn:focus-visible {
   background: var(--door-color-accent-soft);
   border-color: var(--door-color-accent);
   box-shadow: var(--door-focus-ring);
+}
+
+.door-header-btn {
+  border: 1px solid var(--door-color-border-strong);
+  background: var(--door-color-surface);
+  color: var(--door-color-text);
+}
+
+.door-header-btn:hover,
+.door-header-btn:focus-visible {
+  color: var(--door-color-accent-strong);
 }
 
 .door-shell {


### PR DESCRIPTION
## Summary
- add defensive door.json load/save helpers that reseed corrupted data and improve logging
- return richer payloads from delete/search endpoints and refresh bootstrap messaging for the Door shell
- update the Door header/JS to expose a refresh control, console diagnostics, and align styling with the UNI palette

## Testing
- php -l CLOUD/cloud.php

------
https://chatgpt.com/codex/tasks/task_e_68e177afda54832c971672636b623ffa