### PR TITLE
Ensure Door always opens files via openFile

### DIFF
--- a/CLOUD/assets/js/cloud-door.js
+++ b/CLOUD/assets/js/cloud-door.js
@@ -303,7 +303,6 @@
     if (item.kind === 'folder') {
       navigateTo(item.path);
     } else {
-      if (!state.drawer.supportsRaw) return;
       openFile(item);
     }
   }


### PR DESCRIPTION
## Summary
- remove the early raw-support guard so file tiles always invoke openFile

## Testing
- Not run (not possible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e182ed8a14832c953e52c7ab5a69d0